### PR TITLE
Lovefiend, round 2

### DIFF
--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -13,7 +13,7 @@ GLOBAL_LIST_INIT(character_flaws, list(
 	"Wood Arm (L)"=/datum/charflaw/limbloss/arm_l,
 	"Hunted"=/datum/charflaw/dead_or_alive,
 	"Fire Servant"=/datum/charflaw/addiction/pyromaniac,
-	"Love Fiend" = /datum/charflaw/addiction/lovefiend, // REDMOON ADD - love_fiend_back
+	"Ache For Love" = /datum/charflaw/addiction/lovefiend, // REDMOON ADD - love_fiend_back,
 	"Random or No Flaw"=/datum/charflaw/randflaw,
 	"No Flaw (3 TRIUMPHS)"=/datum/charflaw/noflaw
 	))

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -13,6 +13,7 @@ GLOBAL_LIST_INIT(character_flaws, list(
 	"Wood Arm (L)"=/datum/charflaw/limbloss/arm_l,
 	"Hunted"=/datum/charflaw/dead_or_alive,
 	"Fire Servant"=/datum/charflaw/addiction/pyromaniac,
+	"Love Fiend" = /datum/charflaw/addiction/lovefiend, // REDMOON ADD - love_fiend_back
 	"Random or No Flaw"=/datum/charflaw/randflaw,
 	"No Flaw (3 TRIUMPHS)"=/datum/charflaw/noflaw
 	))

--- a/code/datums/sexcon/sexcon.dm
+++ b/code/datums/sexcon/sexcon.dm
@@ -227,7 +227,7 @@
 		user.apply_status_effect(/datum/status_effect/debuff/cumbrained)
 	SSticker.cums++
 	cuckold_check()
-
+	consensual_act_check() // REDMOON ADD - love_fiend_back - проверка на добровольный секс
 
 /datum/sex_controller/proc/after_milking()
 	set_arousal(80)

--- a/code/datums/sexcon/sexcon.dm
+++ b/code/datums/sexcon/sexcon.dm
@@ -227,7 +227,6 @@
 		user.apply_status_effect(/datum/status_effect/debuff/cumbrained)
 	SSticker.cums++
 	cuckold_check()
-	consensual_act_check() // REDMOON ADD - love_fiend_back - проверка на добровольный секс
 
 /datum/sex_controller/proc/after_milking()
 	set_arousal(80)

--- a/code/datums/sexcon/sexcon.dm
+++ b/code/datums/sexcon/sexcon.dm
@@ -228,6 +228,7 @@
 	SSticker.cums++
 	cuckold_check()
 
+
 /datum/sex_controller/proc/after_milking()
 	set_arousal(80)
 	user.emote("sexmoanhvy", forced = TRUE)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -544,7 +544,7 @@
 					if(2)
 						. += span_love("Looks like [p_they()] tries to find someone.")
 					if(3)
-						. += span_love("[t_He]'s heart seem[p_s()] to ache for love.")
+						. += span_love("[p_their(TRUE)] heart seem[p_s()] to ache for love.")
 					if(4)
 						. += span_love("Feels like [p_they()] is lonely.")
 					if(5)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -534,6 +534,23 @@
 			if(-INFINITY to -5)
 				. += span_warning("<B>[t_He] look[p_s()] much weaker than I.</B>")
 
+		// REDMOON ADD - love_fiend_back - визуальное опознание персонажей, ищущих отношения
+		if(!appears_dead && stat == CONSCIOUS && has_flaw(/datum/charflaw/addiction/lovefiend))
+			var/datum/charflaw/addiction/flaw = charflaw
+			if(!flaw.sated)
+				switch(rand(1,5))
+					if(1)
+						. += span_love("[t_He] look[p_s()] lonely.")
+					if(2)
+						. += span_love("Looks like [p_they()] tries to find someone.")
+					if(3)
+						. += span_love("[t_He]'s heart seem[p_s()] to ache for love.")
+					if(4)
+						. += span_love("Feels like [p_they()] is lonely.")
+					if(5)
+						. += span_love("[t_He] tries to catch a glance.")
+		// REDMOON ADD END
+
 	if(maniac)
 		var/obj/item/organ/heart/heart = getorganslot(ORGAN_SLOT_HEART)
 		if(heart)

--- a/modular_redmoon/modules/lovefiend_returns/love_fiend_returns.dm
+++ b/modular_redmoon/modules/lovefiend_returns/love_fiend_returns.dm
@@ -1,5 +1,5 @@
 /datum/charflaw/addiction/lovefiend
-	name = "Love Fiend"
+	name = "Ache For Love"
 	desc = "My heart aches to have consensual love with someone..."
 	time = 1 HOURS
 	needsate_text = "My heart aches for love!.."

--- a/modular_redmoon/modules/lovefiend_returns/love_fiend_returns.dm
+++ b/modular_redmoon/modules/lovefiend_returns/love_fiend_returns.dm
@@ -1,0 +1,49 @@
+/datum/charflaw/addiction/lovefiend
+	name = "Love Fiend"
+	desc = "My heart aches have consensual love with someone..."
+	time = 1 HOURS
+	needsate_text = "My heart aches for love!.."
+
+/datum/sex_controller/proc/consensual_act_check()
+	var/mob/living/carbon/human/partner = null
+
+	// Поиск партнёра на том же тайле
+	for(var/mob/living/carbon/human/potential_partner in range(1, src))
+		// Вычеркиваем себя из списка
+		if(potential_partner == user)
+			continue
+		// Только добровольная любовь во имя Эоры
+		if(need_to_be_violated(potential_partner))
+			continue
+		else
+			partner = potential_partner
+			break
+
+	// Если не удаётся найти на одном и том же тайле партнёра, ищем на тайлах вокруг
+	if(!partner)
+		for(var/mob/living/carbon/human/potential_partner in range(2, src))
+			// Вычеркиваем себя из списка
+			if(potential_partner == user)
+				continue
+			// Только добровольная любовь во имя Эоры
+			if(need_to_be_violated(potential_partner))
+				continue
+			else
+				partner = potential_partner
+				break
+
+	// Всё ещё не смогли найти партнёра. Проверка не пройдена
+	if(!partner)
+		if(user.has_flaw(/datum/charflaw/addiction/lovefiend))
+			to_chat(user, span_boldred("I want to have consensual love with someone..."))
+			return
+
+	// What the fuck have you done
+	if(partner.stat == DEAD)
+		if(user.has_flaw(/datum/charflaw/addiction/lovefiend))
+			to_chat(user, span_boldred("I want to love someone ALIVE!"))
+			return FALSE
+
+	// TODO - в будущем нужно реализовать привязку к партнёру, делающему действие, а не к поиску людей вокруг
+	if(user.has_flaw(/datum/charflaw/addiction/lovefiend))
+		user.sate_addiction()

--- a/modular_redmoon/modules/lovefiend_returns/love_fiend_returns.dm
+++ b/modular_redmoon/modules/lovefiend_returns/love_fiend_returns.dm
@@ -1,6 +1,6 @@
 /datum/charflaw/addiction/lovefiend
 	name = "Love Fiend"
-	desc = "My heart aches have consensual love with someone..."
+	desc = "My heart aches to have consensual love with someone..."
 	time = 1 HOURS
 	needsate_text = "My heart aches for love!.."
 
@@ -8,7 +8,7 @@
 	var/mob/living/carbon/human/partner = null
 
 	// Поиск партнёра на том же тайле
-	for(var/mob/living/carbon/human/potential_partner in range(1, src))
+	for(var/mob/living/carbon/human/potential_partner in range(1, user))
 		// Вычеркиваем себя из списка
 		if(potential_partner == user)
 			continue
@@ -21,7 +21,7 @@
 
 	// Если не удаётся найти на одном и том же тайле партнёра, ищем на тайлах вокруг
 	if(!partner)
-		for(var/mob/living/carbon/human/potential_partner in range(2, src))
+		for(var/mob/living/carbon/human/potential_partner in range(2, user))
 			// Вычеркиваем себя из списка
 			if(potential_partner == user)
 				continue
@@ -44,6 +44,6 @@
 			to_chat(user, span_boldred("I want to love someone ALIVE!"))
 			return FALSE
 
-	// TODO - в будущем нужно реализовать привязку к партнёру, делающему действие, а не к поиску людей вокруг
+	// TODO - в будущем нужно реализовать привязку к партнёру, делающему действие, а не к поиску людей вокруг. Сделано так, чтобы не нужно было заканчивать в партнёра в обязаловке
 	if(user.has_flaw(/datum/charflaw/addiction/lovefiend))
 		user.sate_addiction()

--- a/modular_redmoon/modules/lovefiend_returns/love_fiend_returns.dm
+++ b/modular_redmoon/modules/lovefiend_returns/love_fiend_returns.dm
@@ -15,6 +15,9 @@
 		// Только добровольная любовь во имя Эоры
 		if(need_to_be_violated(potential_partner))
 			continue
+		// Партнёр должен быть с игроком
+		if(!partner.mind)
+			continue
 		else
 			partner = potential_partner
 			break
@@ -27,6 +30,9 @@
 				continue
 			// Только добровольная любовь во имя Эоры
 			if(need_to_be_violated(potential_partner))
+				continue
+			// Партнёр должен быть с игроком
+			if(!partner.mind)
 				continue
 			else
 				partner = potential_partner

--- a/modular_redmoon/modules/lovefiend_returns/love_fiend_returns.dm
+++ b/modular_redmoon/modules/lovefiend_returns/love_fiend_returns.dm
@@ -16,7 +16,7 @@
 		if(need_to_be_violated(potential_partner))
 			continue
 		// Партнёр должен быть с игроком
-		if(!partner.mind)
+		if(!potential_partner.mind)
 			continue
 		else
 			partner = potential_partner
@@ -32,7 +32,7 @@
 			if(need_to_be_violated(potential_partner))
 				continue
 			// Партнёр должен быть с игроком
-			if(!partner.mind)
+			if(!potential_partner.mind)
 				continue
 			else
 				partner = potential_partner

--- a/modular_redmoon/modules/lovefiend_returns/love_fiend_returns.dm
+++ b/modular_redmoon/modules/lovefiend_returns/love_fiend_returns.dm
@@ -4,6 +4,10 @@
 	time = 1 HOURS
 	needsate_text = "My heart aches for love!.."
 
+/datum/sex_controller/after_ejaculation()
+	. = ..()
+	consensual_act_check()
+
 /datum/sex_controller/proc/consensual_act_check()
 	var/mob/living/carbon/human/partner = null
 

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2169,6 +2169,7 @@
 #include "modular_redmoon\modules\jobs\job_types\roguetown\youngfolk\shophand.dm"
 #include "modular_redmoon\modules\jobs\job_types\roguetown\youngfolk\smith_apprentice.dm"
 #include "modular_redmoon\modules\jobs\job_types\roguetown\youngfolk\squire.dm"
+#include "modular_redmoon\modules\lovefiend_returns\love_fiend_returns.dm"
 #include "modular_redmoon\modules\mob\living\carbon\human\species_types\_species.dm"
 #include "modular_redmoon\modules\mob\living\carbon\human\species_types\roguetown\aasimar.dm"
 #include "modular_redmoon\modules\mob\living\carbon\human\species_types\roguetown\anthromorph.dm"


### PR DESCRIPTION
# Описание

Возвращён перк Lovefind, но переделан.

Вместо необходимости просто достигнуть пика, необходимо сделать это вместе с кем-то, кто будет согласен на любовь.

В теории, это должно защитить от Rape Hobo, которые берут бандитов/стражников/другую силовую роль/бомжей, которые берут силовую роль, чтобы иметь валид украсть селянку для нон-кона.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

Больше квирков - богу квирков.

## Демонстрация изменений

По сути, простые проверки.
