### PR TITLE
Round End Vote

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -307,6 +307,16 @@ SUBSYSTEM_DEF(vote)
 			. += "(<a href='?src=[REF(src)];vote=cancel'>Cancel Vote</a>) "
 	else
 		. += "<h2>Start a vote:</h2><hr><ul><li>"
+		// REDMOON ADD START - votes_for_people - воут на Round End
+		var/round_end_vote_allowed_to_players = CONFIG_GET(flag/allow_vote_round_end)
+		if(trialmin || round_end_vote_allowed_to_players)
+			. += "<a href='?src=[REF(src)];vote=round_end'>End Round (after 15 minutes)</a>"
+		else
+			. += "<font color='grey'>End Round (Disallowed)</font>"
+		if(trialmin)
+			. += "\t(<a href='?src=[REF(src)];vote=toggle_round_end'>[round_end_vote_allowed_to_players ? "Allowed" : "Disallowed"]</a>)"
+		. += "</li><li>"
+		// REDMOON ADD END
 		//restart
 		var/avr = CONFIG_GET(flag/allow_vote_restart)
 		if(trialmin || avr)
@@ -361,6 +371,11 @@ SUBSYSTEM_DEF(vote)
 		if("cancel")
 			if(usr.client.holder)
 				reset()
+		// REDMOON ADD START - votes_for_people - воут на Round End
+		if("toggle_round_end")
+			if(usr.client.holder && trialmin)
+				CONFIG_SET(flag/allow_vote_round_end, !CONFIG_GET(flag/allow_vote_round_end))
+		// REDMOON ADD END
 		if("toggle_restart")
 			if(usr.client.holder && trialmin)
 				CONFIG_SET(flag/allow_vote_restart, !CONFIG_GET(flag/allow_vote_restart))
@@ -370,6 +385,11 @@ SUBSYSTEM_DEF(vote)
 		if("toggle_map")
 			if(usr.client.holder && trialmin)
 				CONFIG_SET(flag/allow_vote_map, !CONFIG_GET(flag/allow_vote_map))
+		// REDMOON ADD START - votes_for_people - воут на Round End
+		if("round_end")
+			if(CONFIG_GET(flag/allow_vote_round_end) || usr.client.holder)
+				initiate_vote("endround",usr.key)
+		// REDMOON ADD END
 		if("restart")
 			if(CONFIG_GET(flag/allow_vote_restart) || usr.client.holder)
 				initiate_vote("restart",usr.key)

--- a/config/config.txt
+++ b/config/config.txt
@@ -6,6 +6,7 @@ $include comms.txt
 $include antag_rep.txt
 $include discord.txt
 $include ratwood.txt
+$include config_redmoon.txt
 
 # You can use the @ character at the beginning of a config option to lock it from being edited in-game
 # Example usage:

--- a/config/config_redmoon.txt
+++ b/config/config_redmoon.txt
@@ -1,0 +1,6 @@
+## Enable global barks
+## Uncomment this to allow player's speech barks #
+ENABLE_GLOBAL_BARKS
+
+## allow players to initiate the round end vote
+ALLOW_VOTE_ROUND_END

--- a/config/ratwood.txt
+++ b/config/ratwood.txt
@@ -10,7 +10,3 @@
 ## Roundstart ping
 ## Won't do anything if unset
 #NEW_ROUND_PING
-
-# Enable global barks
-# Uncomment this to allow player's speech barks #
-ENABLE_GLOBAL_BARKS

--- a/modular_redmoon/modules/round_end_vote_for_people/round_end_vote_for_people.dm
+++ b/modular_redmoon/modules/round_end_vote_for_people/round_end_vote_for_people.dm
@@ -1,0 +1,1 @@
+/datum/config_entry/flag/allow_vote_round_end	// allow votes to end round

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2191,4 +2191,5 @@
 #include "modular_redmoon\modules\mob\living\carbon\human\species_types\roguetown\tabaxi.dm"
 #include "modular_redmoon\modules\mob\living\carbon\human\species_types\roguetown\tiefling.dm"
 #include "modular_redmoon\modules\mob\living\carbon\human\species_types\roguetown\vulpkanin.dm"
+#include "modular_redmoon\modules\round_end_vote_for_people\round_end_vote_for_people.dm"
 // END_INCLUDE


### PR DESCRIPTION
# Описание

Добавлена опция для голосования за конец раунда.

Самый обычный round end vote. Изначально, доступна только админам. Есть флаг в конфигах для возможности всем (что на мой взгляд более правильно). Админы в течении раунда могут переключать туда-сюда возможность голосовать.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

Никаких воутов на рестарт.
