### PR TITLE
Fix for wooden platforms

### DIFF
--- a/code/modules/roguetown/roguecrafting/turfs.dm
+++ b/code/modules/roguetown/roguecrafting/turfs.dm
@@ -24,13 +24,13 @@
 	reqs = list(/obj/item/natural/wood/plank = 1)
 	skill_level = 2
 
-/datum/crafting_recipe/roguetown/turfs/wood/platform
+/datum/crafting_recipe/roguetown/turfs/wood/platform // REDMOON EDIT - fix_for_wooden_platforms - was /datum/crafting_recipe/roguetown/turfs/wood/woodplatform
 	name = "platform (wood)"
 	result = /turf/open/floor/rogue/ruinedwood/platform
 	reqs = list(/obj/item/natural/wood/plank = 2)
 	skill_level = 3
 
-/datum/crafting_recipe/roguetown/turfs/wood/platform/TurfCheck(mob/user, turf/T)
+/datum/crafting_recipe/roguetown/turfs/wood/platform/TurfCheck(mob/user, turf/T) // REDMOON EDIT - fix_for_wooden_platforms - was /datum/crafting_recipe/roguetown/turfs/woodenplatform
 	if(isclosedturf(T))
 		return
 	if(!istype(T, /turf/open/transparent/openspace))

--- a/code/modules/roguetown/roguecrafting/turfs.dm
+++ b/code/modules/roguetown/roguecrafting/turfs.dm
@@ -24,12 +24,13 @@
 	reqs = list(/obj/item/natural/wood/plank = 1)
 	skill_level = 2
 
-/datum/crafting_recipe/roguetown/turfs/wood/woodplatform
+/datum/crafting_recipe/roguetown/turfs/wood/platform
 	name = "platform (wood)"
 	result = /turf/open/floor/rogue/ruinedwood/platform
 	reqs = list(/obj/item/natural/wood/plank = 2)
 	skill_level = 3
-/datum/crafting_recipe/roguetown/turfs/woodplatform/TurfCheck(mob/user, turf/T)
+
+/datum/crafting_recipe/roguetown/turfs/wood/platform/TurfCheck(mob/user, turf/T)
 	if(isclosedturf(T))
 		return
 	if(!istype(T, /turf/open/transparent/openspace))

--- a/code/modules/roguetown/roguecrafting/turfs.dm
+++ b/code/modules/roguetown/roguecrafting/turfs.dm
@@ -30,7 +30,7 @@
 	reqs = list(/obj/item/natural/wood/plank = 2)
 	skill_level = 3
 
-/datum/crafting_recipe/roguetown/turfs/wood/platform/TurfCheck(mob/user, turf/T) // REDMOON EDIT - fix_for_wooden_platforms - was /datum/crafting_recipe/roguetown/turfs/woodenplatform
+/datum/crafting_recipe/roguetown/turfs/wood/platform/TurfCheck(mob/user, turf/T) // REDMOON EDIT - fix_for_wooden_platforms - was /datum/crafting_recipe/roguetown/turfs/woodplatform/TurfCheck(mob/user, turf/T)
 	if(isclosedturf(T))
 		return
 	if(!istype(T, /turf/open/transparent/openspace))


### PR DESCRIPTION
# Описание

Позволяет снова крафтить деревянные платформы

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

Fix

## Демонстрация изменений

