### PR TITLE
Surgery No Cooldown Strikes Fix

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -114,6 +114,10 @@
 				var/input = input(user, "Which surgery step do you want to perform?", "PESTRA", ) as null|anything in possible_steps
 				if(input)
 					done_step = possible_steps[input]
+				// REDMOON ADD START - фикс нанесения ударов без КД при распиливании костей (бой со скелетами)
+				else
+					return TRUE
+				// REDMOON ADD END
 			else
 				done_step = possible_steps[possible_steps[1]]
 			if(done_step?.try_op(user, src, user.zone_selected, I, user.used_intent, try_to_fail))


### PR DESCRIPTION
# Описание

Если проводить хирургическую операцию на этапе с открытой костью ИЛИ ДРАТЬСЯ СО СКЕЛЕТОМ БЕЗ БОЕВОГО РЕЖИМА, открывается панелька операции. Сбрасывая операции (на груди в частности или шее), наносишь удары без КД.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

Фиксим баги боевки.

## Демонстрация изменений

![image](https://github.com/user-attachments/assets/f42e7639-ae5d-461a-8248-b17d660ce20b)
