### PR TITLE
Фикс капюшона плащей, который превращается в 2 клетки

### DIFF
--- a/modular_redmoon/modules/cloak_hoods_fix/cloak_hoods_fix.dm
+++ b/modular_redmoon/modules/cloak_hoods_fix/cloak_hoods_fix.dm
@@ -1,0 +1,2 @@
+/obj/item/clothing/head/hooded/rainhood
+	allow_self_unequip = FALSE // маленький хак, чтобы нельзя было поместить капюшон в слоты хранения плаща, тем самым сломав его иконку

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2087,6 +2087,7 @@
 #include "modular_redmoon\modules\acolytes_can_coronate\acolytes_can_coronate.dm"
 #include "modular_redmoon\modules\client\preferences.dm"
 #include "modular_redmoon\modules\client\preferences_savefile.dm"
+#include "modular_redmoon\modules\cloak_hoods_fix\cloak_hoods_fix.dm"
 #include "modular_redmoon\modules\events\goblininvasion.dm"
 #include "modular_redmoon\modules\events\haunts.dm"
 #include "modular_redmoon\modules\events\poltergeist.dm"


### PR DESCRIPTION
# Описание

Если капюшон плаща drag-drop'ом поместить в собственный плащ, то он превратится в 2 клетки, перекрывая обзор. Не чинится ингейм.

Маленький запрет на снятие не через ПКМ по плащу убирает такую проблему.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

Фиксы

## Демонстрация изменений

![dreamseeker_DRJ6xkEWmE](https://github.com/user-attachments/assets/4d6b2682-52e6-4318-b185-bc46ab5dfda6)
