### PR TITLE
Non-con изменён

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -871,7 +871,7 @@ GLOBAL_LIST_INIT(name_adjustments, list())
 	dat += "<td width='33%' align='right'>"
 	if(usr?.client?.prefs?.be_russian)
 		dat += "<b>Русскоязычность:</b> <a href='?_src_=prefs;preference=be_russian'>[(be_russian) ? "Yes":"No"]</a><br>"
-		dat += "<b>Нон-Кон:</b> <a href='?_src_=prefs;preference=be_defiant'>[(defiant) ? "Yes":"No"]</a><br>"
+		dat += "<b>Давать отпор:</b> <a href='?_src_=prefs;preference=be_defiant'>[(defiant) ? "Yes":"No"]</a><br>"
 		dat += "<b>Девственность:</b> <a href='?_src_=prefs;preference=be_virgin'>[(virginity) ? "Yes":"No"]</a><br>"
 		dat += "<b>Быть Голосом:</b> <a href='?_src_=prefs;preference=schizo_voice'>[(toggles & SCHIZO_VOICE) ? "Enabled":"Disabled"]</a>"
 	else


### PR DESCRIPTION
# Описание
Лёгкое изменение строчки Non-Con в настройках куклы: в русском варианте изменено на "Давать отпор".

## Причина изменений
В формулировке Be Defiant (Быть сопротивляющимся) YES означал сопротивление нонкону и NO - смирение при изнасиловании. Из-за этого люди были в непонятках, что именно оно означает, ибо Non-Con: Yes выдавал в чат подсказку, что кукла будет отбиваться в комбат моде. И Non-Con: No давал текст, что кукла будет смиряться.

Теперь оно будет более интуитивно и согласованно по конструкции "название --> подсказка".

## Демонстрация изменений
![non-con](https://github.com/user-attachments/assets/43210496-8eae-4593-ab46-94ee62aacf39)