### PR TITLE
Убирание форсирования гениталий

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -117,10 +117,10 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		ORGAN_SLOT_LIVER = /obj/item/organ/liver,
 		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach,
 		ORGAN_SLOT_APPENDIX = /obj/item/organ/appendix,
-		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles,
-		ORGAN_SLOT_PENIS = /obj/item/organ/penis,
-		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts,
-		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina,
+//		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles, // REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_PENIS = /obj/item/organ/penis, // REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts, // REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina, // REDMOON REMOVAL - убираем форсирование половых органов
 		)
 	/// List of bodypart features of this species
 	var/list/bodypart_features

--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
@@ -63,10 +63,10 @@
 		ORGAN_SLOT_LIVER = /obj/item/organ/liver,
 		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach,
 		ORGAN_SLOT_APPENDIX = /obj/item/organ/appendix,
-		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles,
-		ORGAN_SLOT_PENIS = /obj/item/organ/penis/knotted,
-		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts,
-		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina,
+//		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles, // REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_PENIS = /obj/item/organ/penis/knotted, // REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts, // REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina, // REDMOON REMOVAL - убираем форсирование половых органов
 		)
 	bodypart_features = list(
 		/datum/bodypart_feature/hair/head,

--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorphsmall.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorphsmall.dm
@@ -57,10 +57,10 @@
 		ORGAN_SLOT_LIVER = /obj/item/organ/liver,
 		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach,
 		ORGAN_SLOT_APPENDIX = /obj/item/organ/appendix,
-		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles,
-		ORGAN_SLOT_PENIS = /obj/item/organ/penis/tapered,
-		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts,
-		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina,
+//		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles, // REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_PENIS = /obj/item/organ/penis/tapered, // REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts, // REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina, // REDMOON REMOVAL - убираем форсирование половых органов
 		)
 	bodypart_features = list(
 		/datum/bodypart_feature/hair/head,

--- a/code/modules/mob/living/carbon/human/species_types/furry/axian.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/axian.dm
@@ -71,10 +71,10 @@
 		ORGAN_SLOT_APPENDIX = /obj/item/organ/appendix,
 		//ORGAN_SLOT_TAIL = /obj/item/organ/tail/akula, //Commenting out due to use of customizer organs.
 		ORGAN_SLOT_SNOUT = /obj/item/organ/snout/akula,
-		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles,
-		ORGAN_SLOT_PENIS = /obj/item/organ/penis/tapered,
-		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts,
-		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina,
+//		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles, // REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_PENIS = /obj/item/organ/penis/tapered, // REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts, // REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina, // REDMOON REMOVAL - убираем форсирование половых органов
 		)
 	bodypart_features = list(
 		/datum/bodypart_feature/hair/head,

--- a/code/modules/mob/living/carbon/human/species_types/furry/dracon.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/dracon.dm
@@ -77,10 +77,10 @@
 		ORGAN_SLOT_FRILLS = /obj/item/organ/frills/lizard,
 		ORGAN_SLOT_HORNS = /obj/item/organ/horns,
 		ORGAN_SLOT_WINGS = /obj/item/organ/wings/dracon,
-		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles,
-		ORGAN_SLOT_PENIS = /obj/item/organ/penis/tapered,
-		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts,
-		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina,
+//		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles, // REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_PENIS = /obj/item/organ/penis/tapered, // REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts, // REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina, // REDMOON REMOVAL - убираем форсирование половых органов
 		)
 	customizers = list(
 		/datum/customizer/organ/eyes/humanoid,

--- a/code/modules/mob/living/carbon/human/species_types/furry/kobold.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/kobold.dm
@@ -57,10 +57,10 @@
 		ORGAN_SLOT_SNOUT = /obj/item/organ/snout/lizard,
 		ORGAN_SLOT_FRILLS = /obj/item/organ/frills/lizard,
 		ORGAN_SLOT_HORNS = /obj/item/organ/horns,
-		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles,
-		ORGAN_SLOT_PENIS = /obj/item/organ/penis/tapered,
-		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts,
-		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina,
+//		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_PENIS = /obj/item/organ/penis/tapered, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina, REDMOON REMOVAL - убираем форсирование половых органов
 		)
 	customizers = list(
 		/datum/customizer/organ/eyes/humanoid,

--- a/code/modules/mob/living/carbon/human/species_types/furry/lizardfolk.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/lizardfolk.dm
@@ -68,10 +68,10 @@
 		ORGAN_SLOT_TAIL_FEATURE = /obj/item/organ/tail_feature/lizard_spines,
 		ORGAN_SLOT_FRILLS = /obj/item/organ/frills/lizard,
 		ORGAN_SLOT_HORNS = /obj/item/organ/horns,
-		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles,
-		ORGAN_SLOT_PENIS = /obj/item/organ/penis/tapered,
-		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts,
-		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina,
+//		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_PENIS = /obj/item/organ/penis/tapered, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina, REDMOON REMOVAL - убираем форсирование половых органов
 		)
 	customizers = list(
 		/datum/customizer/organ/eyes/humanoid,

--- a/code/modules/mob/living/carbon/human/species_types/furry/lupian.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/lupian.dm
@@ -76,10 +76,10 @@
 		ORGAN_SLOT_APPENDIX = /obj/item/organ/appendix,
 		ORGAN_SLOT_TAIL = /obj/item/organ/tail/lupian,
 		ORGAN_SLOT_SNOUT = /obj/item/organ/snout/lupian,
-		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles,
-		ORGAN_SLOT_PENIS = /obj/item/organ/penis/knotted,
-		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts,
-		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina,
+//		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles,  REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_PENIS = /obj/item/organ/penis/knotted,  REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts,  REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina,  REDMOON REMOVAL - убираем форсирование половых органов
 		)
 	bodypart_features = list(
 		/datum/bodypart_feature/hair/head,

--- a/code/modules/mob/living/carbon/human/species_types/furry/moth.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/moth.dm
@@ -52,10 +52,10 @@
 		ORGAN_SLOT_ANTENNAS = /obj/item/organ/antennas/moth,
 		ORGAN_SLOT_NECK_FEATURE = /obj/item/organ/neck_feature/moth_fluff,
 		ORGAN_SLOT_WINGS = /obj/item/organ/wings/moth,
-		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles,
-		ORGAN_SLOT_PENIS = /obj/item/organ/penis/tapered,
-		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts,
-		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina,
+//		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_PENIS = /obj/item/organ/penis/tapered, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina, REDMOON REMOVAL - убираем форсирование половых органов
 		)
 	customizers = list(
 		/datum/customizer/organ/eyes/moth,

--- a/code/modules/mob/living/carbon/human/species_types/furry/tabaxi.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/tabaxi.dm
@@ -62,10 +62,10 @@
 		ORGAN_SLOT_APPENDIX = /obj/item/organ/appendix,
 		//ORGAN_SLOT_TAIL = /obj/item/organ/tail/cat, //Commenting out due to use of customizer organs.
 		ORGAN_SLOT_SNOUT = /obj/item/organ/snout/cat,
-		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles,
-		ORGAN_SLOT_PENIS = /obj/item/organ/penis/barbed,
-		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts,
-		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina,
+//		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_PENIS = /obj/item/organ/penis/barbed, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina,  REDMOON REMOVAL - убираем форсирование половых органов
 		)
 	bodypart_features = list(
 		/datum/bodypart_feature/hair/head,

--- a/code/modules/mob/living/carbon/human/species_types/furry/vulpkanin.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/vulpkanin.dm
@@ -55,10 +55,10 @@
 		ORGAN_SLOT_APPENDIX = /obj/item/organ/appendix,
 		//ORGAN_SLOT_TAIL = /obj/item/organ/tail/vulpkanin, //Commenting out due to use of customizer organs.
 		ORGAN_SLOT_SNOUT = /obj/item/organ/snout/vulpkanin,
-		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles,
-		ORGAN_SLOT_PENIS = /obj/item/organ/penis/knotted,
-		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts,
-		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina,
+//		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_PENIS = /obj/item/organ/penis/knotted, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina, REDMOON REMOVAL - убираем форсирование половых органов
 		)
 	bodypart_features = list(
 		/datum/bodypart_feature/hair/head,

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/goblin/goblinp.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/goblin/goblinp.dm
@@ -30,10 +30,10 @@
 		ORGAN_SLOT_LIVER = /obj/item/organ/liver,
 		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach,
 		ORGAN_SLOT_APPENDIX = /obj/item/organ/appendix,
-		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles,
-		ORGAN_SLOT_PENIS = /obj/item/organ/penis,
-		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts,
-		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina,
+//		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_PENIS = /obj/item/organ/penis, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina, REDMOON REMOVAL - убираем форсирование половых органов
 		)
 	offset_features = list(
 		OFFSET_ID = list(0,0), OFFSET_GLOVES = list(0,0), OFFSET_WRISTS = list(0,0),\

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
@@ -71,7 +71,7 @@
 		/datum/customizer/bodypart_feature/accessory,
 		/datum/customizer/bodypart_feature/face_detail,
 		/datum/customizer/organ/testicles/human,
-		/datum/customizer/organ/penis/human,
+		/datum/customizer/organ/penis/equine, // REDMOON EDIT - заменяем на более "подходящее" - WAS: /datum/customizer/organ/penis/human,
 		/datum/customizer/organ/breasts/human,
 		/datum/customizer/organ/vagina/human,
 		)

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
@@ -64,10 +64,10 @@
 		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach,
 		ORGAN_SLOT_APPENDIX = /obj/item/organ/appendix,
 		ORGAN_SLOT_HORNS = /obj/item/organ/horns/halforc,
-		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles,
-		ORGAN_SLOT_PENIS = /obj/item/organ/penis,
-		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts,
-		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina,
+//		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_PENIS = /obj/item/organ/penis, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts, REDMOON REMOVAL - убираем форсирование половых органов
+//		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina, REDMOON REMOVAL - убираем форсирование половых органов
 		)
 	body_markings = list(
 		/datum/body_marking/tonage,

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
@@ -82,7 +82,7 @@
 		/datum/customizer/organ/horns/humanoid/tiefling,
 		/datum/customizer/organ/tail/tiefling,
 		/datum/customizer/organ/testicles/human,
-		/datum/customizer/organ/penis/human,
+		/datum/customizer/organ/penis/anthro, // REDMOON EDIT - заменяем на более "подходящее" - WAS: /datum/customizer/organ/penis/human,
 		/datum/customizer/organ/breasts/human,
 		/datum/customizer/organ/vagina/human,
 		)


### PR DESCRIPTION


# Описание

1. Гениталии больше не форсируются не персонажа, если они не выставлены в кастомизации.
2. Технически, это даёт создать персонажа вовсе без половых органов ИЛИ только с половыми органами другого пола.
3. Пояснительную лоровую бригаду сюда.
4. Алсо, у ~~дренеек~~ появилась каноничная опция по выбору елды.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

Кастомизация.
