### PR TITLE
Логирование изменения PQ, менее спамящее и показывающее реальный CKEY

### DIFF
--- a/code/modules/admin/playerquality.dm
+++ b/code/modules/admin/playerquality.dm
@@ -83,7 +83,8 @@
 			msg += " - RSN: [reason]"
 		message_admins("[admin] [amt>0 ? "повысил" : "снял"] PQ [key][abs(amt) > 1 ? " на [amt]" : ""] за: \"<i>[reason]</i>\"") // REDMOON EDIT
 		log_admin("[admin] adjusted [key]'s PQ by [amt] for reason: [reason]")
-		send2irc("PQ", "[admin] [amt>0 ? "повысил" : "снял"] [key][abs(amt) > 1 ? " на [amt]" : ""] за: \"<i>[reason]</i>\"") // REDMOON ADD
+		if(abs(amt) > 1)
+			send2irc("PQ", "[admin] [amt>0 ? "повысил" : "снял"] [key][abs(amt) > 1 ? " на [amt]" : ""] за: \"<i>[reason]</i>\"") // REDMOON ADD
 
 /client/proc/check_pq()
 	set category = "GameMaster"
@@ -224,6 +225,8 @@
 	var/raisin = stripped_input(src, "Укажите краткую причину этого изменения", "Будь крутым, а не гнилым", "", null)
 	if(!raisin)
 		to_chat(src, span_boldwarning("Причина не указана."))
+		fdel(json_file)
+		WRITE_FILE(json_file, json_encode(json))
 		return FALSE // REDMOON ADD - добавил FALSE
 	// REDMOON ADD END
 
@@ -232,6 +235,7 @@
 //	if(get_playerquality(key) < 29)
 
 		adjust_playerquality(1, ckey(key), fakekey, raisin) // REDMOON EDIT - was adjust_playerquality(1, ckey(key))
+		send2irc("PQ", "[fakekey == ckey ? "[ckey]" : "[fake_key] ([ckey])"] повысил [key] за: \"<i>[raisin]</i>\"") // REDMOON ADD
 	// REDMOON ADD START - похвала без PQ
 		curcomm++
 		json[giver] = curcomm

--- a/modular_redmoon/modules/commend_comments/commend_comments.dm
+++ b/modular_redmoon/modules/commend_comments/commend_comments.dm
@@ -46,6 +46,7 @@
 
 	if(curcomm >= 0) // Если комменд -1 или более, то нельзя дальше анкоммендить
 		adjust_playerquality(-1, ckey(key), fakekey, raisin)
+		send2irc("PQ", "[fakekey == ckey ? "[ckey]" : "[fake_key] ([ckey])"] снял [key] за: \"<i>[raisin]</i>\"") // REDMOON ADD
 		curcomm--
 		json[giver] = curcomm
 		fdel(json_file)


### PR DESCRIPTION
# Описание

1. Сообщения о повышении/понижении PQ больше не будут содержать системные сообщения кроме донатного, вроде 0.1 PQ за закапывание в могиле.
2. IRC сообщения теперь показывают настоящий CKEY повышающего/понижающего PQ.

- [ ] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера 

## Причина изменений

Логирование, меньше спама

## Демонстрация изменений

IRC нет в доступе.