### PR TITLE
Нерф ядовитых стрел до фикса их уничтожения латников

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -105,7 +105,7 @@
 	hitsound = 'sound/combat/hits/hi_arrow2.ogg'
 	poisontype = /datum/reagent/berrypoison //Support for future variations of poison for arrow-crafting
 	poisonfeel = "burning" //Ditto
-	poisonamount = 2 //Support and balance for bodkins, which will hold less poison due to how
+	poisonamount = 1 //Support and balance for bodkins, which will hold less poison due to how
 
 /obj/projectile/bullet/reusable/arrow/poison/stone
 	name = "stone arrow"


### PR DESCRIPTION
# Описание

Временная затычка. Уменьшаем на 50% количество яда в ядовитых стрелах, пока не будет исправлено его попадание сквозь броню.

- [ ] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера 

## Причина изменений

-30% при непробитых латах это мощно

