### PR TITLE
Фикс выкидывания из тела при декапе

### DIFF
--- a/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
+++ b/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
@@ -296,12 +296,14 @@
 
 	name = "[owner.real_name]'s head"
 	. = ..()
+	/* REDMOON REMOVAL START - decap_cannot_reenter_body_fix - очень опасный фикс (т.к. весь код связанный с органами это спагетти) невозможности вернуться в тело
 	if(brainmob)
 		QDEL_NULL(brainmob)
 	var/obj/item/organ/brain/BR = locate(/obj/item/organ/brain) in contents
 	if(BR)
 		if(BR.brainmob)
 			QDEL_NULL(BR.brainmob)
+	REDMOON REMOVAL END */
 
 //Attach a limb to a human and drop any existing limb of that type.
 /obj/item/bodypart/proc/replace_limb(mob/living/carbon/C, special)


### PR DESCRIPTION
# Описание

При декапе, brainmob сразу же удалялся после всех процедур с его перемещением. Этого больше не происходит. По итогу, челы могут вполне себе успешно быть у себя в головёшке.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера 

## Причина изменений

Меньше багов

## Демонстрация изменений

![dreamseeker_K7dAAfdhWt](https://github.com/user-attachments/assets/4b69ae6f-29df-4f30-bbd8-52ec895fcd23)
![dreamseeker_KXYNagDxKf](https://github.com/user-attachments/assets/b41a2c0f-176d-4e03-9b5f-ad851c16c900)
