### PR TITLE
Орисон Пестранцам, "фикс" проблемы вызова пристом массива

### DIFF
--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -157,7 +157,7 @@
 		return
 
 	granted_spells = list()
-	var/list/spelllist = list(patron.t0, patron.t1, patron.t2, patron.t3, patron.t4, /obj/effect/proc_holder/spell/invoked/solar_smite)
+	var/list/spelllist = list(/obj/effect/proc_holder/spell/invoked/lesser_heal, /obj/effect/proc_holder/spell/targeted/touch/orison, patron.t1, patron.t2, patron.t3, patron.t4, /obj/effect/proc_holder/spell/invoked/solar_smite)
 	for(var/spell_type in spelllist)
 		if(!spell_type || H.mind.has_spell(spell_type))
 			continue

--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -113,7 +113,7 @@
 	desc = "The Loving Daughter of Psydon, gifted man medicine."
 	worshippers = "The Sick, Phyicians, Apothecaries"
 	mob_traits = list(TRAIT_EMPATH, TRAIT_ROT_EATER)
-	t0 = list(/obj/effect/proc_holder/spell/invoked/diagnose, /obj/effect/proc_holder/spell/invoked/lesser_heal) // Combine both spells on t0
+	t0 = list(/obj/effect/proc_holder/spell/invoked/diagnose, /obj/effect/proc_holder/spell/invoked/lesser_heal, /obj/effect/proc_holder/spell/targeted/touch/orison) // Combine both spells on t0
 	t1 = /obj/effect/proc_holder/spell/invoked/heal
 	t2 = /obj/effect/proc_holder/spell/invoked/attach_bodypart
 	t3 = /obj/effect/proc_holder/spell/invoked/cure_rot


### PR DESCRIPTION
# Описание
- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

У приста от patron.t0 ломался var/newspell = new spell_type из-за вызова массива (да и у Астраты нету т0), из-за чего не давались спелы вовсе
У Пестранцев единственных не давался Орисон ибо у них свой т0

## Причина изменений

фиксы 

## Демонстрация изменений

![image](https://github.com/user-attachments/assets/bdeaf528-b013-41a3-a3ec-c1ade3509af9)

![image](https://github.com/user-attachments/assets/6117ceeb-ea2c-4f5d-a5b7-fc6e4592a09a)
