### PR TITLE
Чинит классы вампиров, возвращая старые и добавляя вариации новых.

### DIFF
--- a/code/modules/antagonists/roguetown/villain/vampirelord.dm
+++ b/code/modules/antagonists/roguetown/villain/vampirelord.dm
@@ -152,7 +152,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	owner.current.ambushable = FALSE
 
 /mob/living/carbon/human/proc/spawn_pick_class()
-	var/list/classoptions = list("Bard", "Fisher", "Hunter", "Miner", "Peasant", "Woodcutter", "Cheesemaker", "Blacksmith", "Carpenter", "Rogue", "Treasure Hunter", "Mage")
+	var/list/classoptions = list("Minstrel", "Fisher", "Hunter", "Miner", "Peasant", "Woodcutter", "Cheesemaker", "Blacksmith", "Carpenter", "Thief", "Footman", "Battle Magos", "Stalker", "Crossbowman", "Cutthroat")
 	var/list/visoptions = list()
 
 	for(var/T in 1 to 5)


### PR DESCRIPTION

# Добавил вместо старых барда роги и мага их версии из рефугов, так же подходящие для них вариации, заменил трешур хантера который раньше был главной физической силой подсосов - классами в виде мечника и арбалетчика.


<!-- Поменяй этот комментарий на краткое описание изменений, которые ты внёс -->
<!-- Если изменения косметические и ты уверен в их работоспособности, можно не проверять на локальном сервере. -->
<!-- Создавать предложку или багрепорт тоже необязательно. Если же они были, вставь ссылку на них. -->
- [X] Изменения были проверены на локальном сервере
- [X] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Фактически починка бага, что ограничивал профы для стартовых подсосов вампира.

<!-- Тут напиши причину, по которой твой пулл-реквест будет полезен для игры. -->

## Демонстрация не трубется, все работает.

<!-- Можешь вставить тут видео или скриншоты изменений, если они будут полезны для проверяющего пулл-реквест.
	 Вставлять их можно Ctr+C, Ctr+V. -->

<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->
