### PR TITLE
Patch 1

### DIFF
--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -136,8 +136,8 @@
 	icon_state = "plate"
 	max_integrity = 520
 	body_parts_covered = CHEST|GROIN|VITALS|LEGS|ARMS
-	equip_delay_self = 120
-	unequip_delay_self = 120
+	equip_delay_self = 1200
+	unequip_delay_self = 1200
 	equip_delay_other = 60
 	strip_delay = 60
 

--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -136,8 +136,8 @@
 	icon_state = "plate"
 	max_integrity = 520
 	body_parts_covered = CHEST|GROIN|VITALS|LEGS|ARMS
-	equip_delay_self = 1200
-	unequip_delay_self = 1200
+	equip_delay_self = 120
+	unequip_delay_self = 120
 	equip_delay_other = 60
 	strip_delay = 60
 

--- a/code/modules/jobs/job_types/roguetown/refugees/types/amazon.dm
+++ b/code/modules/jobs/job_types/roguetown/refugees/types/amazon.dm
@@ -1,0 +1,52 @@
+/datum/subclass/amazon
+	name = "Amazon"
+	tutorial = "Amazons are warrior-women from the mysterious isle of Issa. These rare fighters are so tough they can beat an average man!"
+	allowed_sexes = list(FEMALE)
+	allowed_races = RACES_ALL_KINDS
+	outfit = /datum/outfit/job/roguetown/refugee/amazon
+	maximum_possible_slots = 5
+	category_tags = list(CTAG_REFUGEE)
+
+	traits_applied = list(TRAIT_CRITICAL_RESISTANCE, TRAIT_NOPAINSTUN, TRAIT_STEELHEARTED)
+	cmode_music = 'sound/music/combat_gronn.ogg'
+
+/datum/outfit/job/roguetown/adventurer/amazon/pre_equip(mob/living/carbon/human/H)
+	..()
+	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
+	belt = /obj/item/storage/belt/rogue/leather
+	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
+	beltl = /obj/item/rogueweapon/huntingknife
+	shoes = /obj/item/clothing/shoes/roguetown/gladiator
+	backl = /obj/item/storage/backpack/rogue/satchel
+	if(prob(23))
+		armor = /obj/item/clothing/suit/roguetown/armor/leather
+	if(prob(23))
+		armor = /obj/item/clothing/suit/roguetown/armor/leather/hide
+	if(prob(50))
+		armor = /obj/item/clothing/suit/roguetown/armor/chainmail/chainkini
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	if(prob(50))
+		shoes = /obj/item/clothing/shoes/roguetown/boots
+	if(prob(75))
+		beltr = /obj/item/rogueweapon/sword/iron
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+	else
+		r_hand = /obj/item/rogueweapon/spear
+		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
+	H.change_stat("strength", 2)
+	H.change_stat("intelligence", -2)
+	H.change_stat("constitution", 3)
+	H.change_stat("perception", 2)
+	H.change_stat("endurance", 2)
+	H.change_stat("speed", 2)

--- a/modular_redmoon/code/modules/roguetown/roguecrafting/items.dm
+++ b/modular_redmoon/code/modules/roguetown/roguecrafting/items.dm
@@ -48,12 +48,12 @@
 	result = /obj/item/clothing/suit/roguetown/armor/leather/masterwork/bikini/bra
 	reqs = list(/obj/item/clothing/suit/roguetown/armor/leather/masterwork/bikini = 1)
 
-/datum/crafting_recipe/roguetown/ichainkiniconv
-	name = "chainmail bikini to bra"
-	result = list(/obj/item/clothing/suit/roguetown/armor/chainmail/iron/bikini/bra)
-	reqs = list(/obj/item/clothing/suit/roguetown/armor/chainmail/iron/bikini = 1)
+/datum/crafting_recipe/roguetown/ichainkiniconvone
+	name = "chainmail to bikini"
+	result = list(/obj/item/clothing/suit/roguetown/armor/chainmail/iron/bikini)
+	reqs = list(/obj/item/clothing/suit/roguetown/armor/chainmail/iron = 1)
 
-/datum/crafting_recipe/roguetown/chainkiniconv
+/datum/crafting_recipe/roguetown/chainkiniconvtwo
 	name = "chainmail bikini to bra"
 	result = list(/obj/item/clothing/suit/roguetown/armor/chainmail/bikini/bra)
 	reqs = list(/obj/item/clothing/suit/roguetown/armor/chainmail/bikini = 1)
@@ -61,7 +61,7 @@
 /datum/crafting_recipe/roguetown/halfplateconvone
 	name = "halfplate armor to bikini"
 	result = list(/obj/item/clothing/suit/roguetown/armor/plate/bikini)
-	reqs = list(/obj/item/clothing/suit/roguetown/armor/plate = 1)
+	reqs = list(obj/item/clothing/ob/suit/roguetown/armor/plate = 1)
 
 /datum/crafting_recipe/roguetown/halfplateconvtwo
 	name = "halfplate bikini to bra"

--- a/modular_redmoon/code/modules/roguetown/roguecrafting/items.dm
+++ b/modular_redmoon/code/modules/roguetown/roguecrafting/items.dm
@@ -61,7 +61,7 @@
 /datum/crafting_recipe/roguetown/halfplateconvone
 	name = "halfplate armor to bikini"
 	result = list(/obj/item/clothing/suit/roguetown/armor/plate/bikini)
-	reqs = list(/obj/item/clothing/obj/suit/roguetown/armor/plate = 1)
+	reqs = list(/obj/item/clothing/suit/roguetown/armor/plate = 1)
 
 /datum/crafting_recipe/roguetown/halfplateconvtwo
 	name = "halfplate bikini to bra"

--- a/modular_redmoon/code/modules/roguetown/roguecrafting/items.dm
+++ b/modular_redmoon/code/modules/roguetown/roguecrafting/items.dm
@@ -61,7 +61,7 @@
 /datum/crafting_recipe/roguetown/halfplateconvone
 	name = "halfplate armor to bikini"
 	result = list(/obj/item/clothing/suit/roguetown/armor/plate/bikini)
-	reqs = list(obj/item/clothing/ob/suit/roguetown/armor/plate = 1)
+	reqs = list(/obj/item/clothing/obj/suit/roguetown/armor/plate = 1)
 
 /datum/crafting_recipe/roguetown/halfplateconvtwo
 	name = "halfplate bikini to bra"


### PR DESCRIPTION
# Описание

- Я добавил новый класс амазонок, слизав их с старороги
- Я снизил задержку надевания и одевания лат, так как действия в игре происходят быстро, следовательно задержка в 1200  просто невообразимое дерьмище. Все были недовольне при принятии ПРа в ру сегменте старороги, пора эту хуйню убирать
- Я убрал дублирующийся крафт кольчужного лифчика из кольчужного бикини. Теперь из обычной кольчуги можно сделать кольчужные бикини. 
- [ ] Изменения были проверены на локальном сервере. 
- [x] Этот пулл-реквест готов к тест-мерджу.


## Причина изменений

новый класс для дрочеров это круто, не затягивать геймплей снятием и надеванием лат это круто!

## Демонстрация изменений

нихуя нету, сорян, ну не компилится у меня билд и все, но я на 99 процентов уверен, что все просто замечательно 
