### PR TITLE
Статистика рас для конца раунда

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -260,40 +260,64 @@
 /datum/controller/subsystem/ticker/proc/stats_report()
 	var/list/shit = list()
 	shit += "<br><span class='bold'>Δ--------------------Δ</span><br>"
-	shit += "<br><font color='#9b6937'><span class='bold'>Deaths:</span></font> [deaths]"
-	shit += "<br><font color='#af2323'><span class='bold'>Blood spilt:</span></font> [round(blood_lost / 100, 1)]L"
-	shit += "<br><font color='#36959c'><span class='bold'>TRIUMPH(s) Awarded:</span></font> [tri_gained]"
-	shit += "<br><font color='#a02fa4'><span class='bold'>TRIUMPH(s) Stolen:</span></font> [tri_lost * -1]"
-	shit += "<br><font color='#ffd4fd'><span class='bold'>Pleasures:</span></font> [cums]"
+	shit += "<br><font color='#9b6937'><span class='bold'>Погибло:</span></font> [deaths]"
+	shit += "<br><font color='#af2323'><span class='bold'>Крови пролито:</span></font> [round(blood_lost / 100, 1)]L"
+	shit += "<br><font color='#36959c'><span class='bold'>Триумфов Получено:</span></font> [tri_gained]"
+	shit += "<br><font color='#a02fa4'><span class='bold'>Триумфов Украдено:</span></font> [tri_lost * -1]"
+	shit += "<br><font color='#ffd4fd'><span class='bold'>Удовольствий:</span></font> [cums]"
 	if(GLOB.cuckolds.len)
-		shit += "<br><font color='#a02fa4'><span class='bold'>Cuckolds were:</span></font> "
+		shit += "<br><font color='#a02fa4'><span class='bold'>Получили рога:</span></font> "
 		for(var/i in 1 to GLOB.cuckolds.len)
 			shit += GLOB.cuckolds[i]
 			if(i != GLOB.cuckolds.len)
 				shit += ","
 	if(GLOB.confessors.len)
-		shit += "<br><font color='#93cac7'><span class='bold'>The Damned:</span></font> "
+		shit += "<br><font color='#93cac7'><span class='bold'>Покаявшиеся инквизитору:</span></font> "
 		for(var/x in GLOB.confessors)
 			shit += "[x]"
 	// REDMOON ADD START
-	//  вывод статистики в конце раунда о количестве семей и осквернённых Баотой
-	shit += "<br><font color='#115726'><span class='bold'>Tried to form up a familty: </span></font> [length(SSfamily.family_candidates)]"
-	shit += "<br><font color='#22833f'><span class='bold'>Families were in Rockhill:</span></font> [SSfamily.families.len]" // family_changes
-	shit += "<br><font color='#a1489d'><span class='bold'>Corrputed by Baotha:</span></font> [SSticker.violated_by_baotha.len]" // baotha_steals_triumphs
+	// вывод статистики в конце раунда о количестве семей и осквернённых Баотой
+	shit += "<br><font color='#115726'><span class='bold'>Пытались создать семью: </span></font> [length(SSfamily.family_candidates)]"
+	shit += "<br><font color='#22833f'><span class='bold'>Семей проживало в Рокхилле:</span></font> [SSfamily.families.len]" // family_changes
+	shit += "<br><font color='#a1489d'><span class='bold'>Осквернено Баотой:</span></font> [SSround_end_statistics.violated_by_baotha.len]" // baotha_steals_triumphs
 	// start_reports_with_gender_lists - вывод статистики в конце раунда о половой принадлежности
-	var/count_of_joined_characters = males + females + males_with_vagina + females_with_penis
-	var/percent_of_males = PERCENT(males/count_of_joined_characters)
-	var/percent_of_males_with_vagina = PERCENT(males_with_vagina/count_of_joined_characters)
-	var/percent_of_females = PERCENT(females/count_of_joined_characters)
-	var/percent_of_females_with_penis = PERCENT(females_with_penis/count_of_joined_characters)
+	var/count_of_joined_characters = SSround_end_statistics.males + SSround_end_statistics.females + SSround_end_statistics.males_with_vagina + SSround_end_statistics.females_with_penis
+	var/percent_of_males = PERCENT(SSround_end_statistics.males/count_of_joined_characters)
+	var/percent_of_males_with_vagina = PERCENT(SSround_end_statistics.males_with_vagina/count_of_joined_characters)
+	var/percent_of_females = PERCENT(SSround_end_statistics.females/count_of_joined_characters)
+	var/percent_of_females_with_penis = PERCENT(SSround_end_statistics.females_with_penis/count_of_joined_characters)
 	shit += "<br><span class='bold'>⇕--------------------⇕</span>"
-	shit += "<br><font color='#a78fa8'><span class='bold'>Beginnings Statistics:</span></font> "
-	shit += "<br><font color='#4183c0'><span class='italics'>Men:</span></font> [males] ([percent_of_males]%)"
-	shit += "<br><font color='#c74ec1'><span class='italics'>Women:</span></font> [females] ([percent_of_females]%)"
-	shit += "<br><font color='#d19445'><span class='italics'>Men with female beginnings:</span></font> [males_with_vagina] ([percent_of_males_with_vagina]%)"
-	shit += "<br><font color='#80097a'><span class='italics'>Women with male beginnings:</span></font> [females_with_penis] ([percent_of_females_with_penis]%)"
+	shit += "<br><font color='#a78fa8'><span class='bold'>Эора подарила Рокхиллу... </span></font> "
+	shit += "<br><font color='#4183c0'><span class='italics'>Мужчин:</span></font> [SSround_end_statistics.males] ([percent_of_males]%)"
+	shit += "<br><font color='#c74ec1'><span class='italics'>Женщин:</span></font> [SSround_end_statistics.females] ([percent_of_females]%)"
+	shit += "<br><font color='#d19445'><span class='italics'>Мужчин с иным началом:</span></font> [SSround_end_statistics.males_with_vagina] ([percent_of_males_with_vagina]%)"
+	shit += "<br><font color='#80097a'><span class='italics'>Женщин с иным началом:</span></font> [SSround_end_statistics.females_with_penis] ([percent_of_females_with_penis]%)"
+	// species_statistics
+	shit += "<br><span class='bold'>⇕--------------------⇕</span>"
+	shit += "<br><font color='#489b53'><span class='bold'>Под солнцем Астраты были...</span></font> "
+	if(SSround_end_statistics.species_aasimar)			shit += "<br><font color='#36693c'><span class='italics'>Аасимары: </span></font>[SSround_end_statistics.species_aasimar]"
+	if(SSround_end_statistics.species_axian)			shit += "<br><font color='#36693c'><span class='italics'>Аксиане: </span></font>[SSround_end_statistics.species_axian]"
+	if(SSround_end_statistics.species_anthromorphsmall) shit += "<br><font color='#36693c'><span class='italics'>Верминволки: </span></font>[SSround_end_statistics.species_anthromorphsmall]"
+	if(SSround_end_statistics.species_vulpkanin)		shit += "<br><font color='#36693c'><span class='italics'>Вульпканин: </span></font>[SSround_end_statistics.species_vulpkanin]"
+	if(SSround_end_statistics.species_goblinp)			shit += "<br><font color='#36693c'><span class='italics'>Гоблины: </span></font>[SSround_end_statistics.species_goblinp]"
+	if(SSround_end_statistics.species_dwarf)			shit += "<br><font color='#36693c'><span class='italics'>Дварфы: </span></font>[SSround_end_statistics.species_dwarf]"
+	if(SSround_end_statistics.species_anthromorph) 		shit += "<br><font color='#36693c'><span class='italics'>Дикари: </span></font>[SSround_end_statistics.species_anthromorph]"
+	if(SSround_end_statistics.species_dracon)			shit += "<br><font color='#36693c'><span class='italics'>Дракониды: </span></font>[SSround_end_statistics.species_dracon]"
+	if(SSround_end_statistics.species_drow)				shit += "<br><font color='#36693c'><span class='italics'>Дроу: </span></font>[SSround_end_statistics.species_drow]"
+	if(SSround_end_statistics.species_kobold)			shit += "<br><font color='#36693c'><span class='italics'>Кобольды: </span></font>[SSround_end_statistics.species_kobold]"
+	if(SSround_end_statistics.species_lupian)			shit += "<br><font color='#36693c'><span class='italics'>Люпины: </span></font>[SSround_end_statistics.species_lupian]"
+	if(SSround_end_statistics.species_humen)			shit += "<br><font color='#36693c'><span class='italics'>Люди: </span></font>[SSround_end_statistics.species_humen]"
+	if(SSround_end_statistics.species_moth)				shit += "<br><font color='#36693c'><span class='italics'>Моли: </span></font>[SSround_end_statistics.species_moth]"
+	if(SSround_end_statistics.species_demihuman)		shit += "<br><font color='#36693c'><span class='italics'>Полукровки: </span></font>[SSround_end_statistics.species_demihuman]"
+	if(SSround_end_statistics.species_halfork)			shit += "<br><font color='#36693c'><span class='italics'>Полуорки: </span></font>[SSround_end_statistics.species_halfork]"
+	if(SSround_end_statistics.species_halfelf)			shit += "<br><font color='#36693c'><span class='italics'>Полуэльфы: </span></font>[SSround_end_statistics.species_halfelf]"
+	if(SSround_end_statistics.species_lizardfolk)		shit += "<br><font color='#36693c'><span class='italics'>Сиссеане: </span></font>[SSround_end_statistics.species_lizardfolk]"
+	if(SSround_end_statistics.species_tabaxi)			shit += "<br><font color='#36693c'><span class='italics'>Табакси: </span></font>[SSround_end_statistics.species_tabaxi]"
+	if(SSround_end_statistics.species_tiefling)			shit += "<br><font color='#36693c'><span class='italics'>Тифлинги: </span></font>[SSround_end_statistics.species_tiefling]"
+	if(SSround_end_statistics.species_seelie)			shit += "<br><font color='#36693c'><span class='italics'>Феи: </span></font>[SSround_end_statistics.species_seelie]"
+	if(SSround_end_statistics.species_elf)				shit += "<br><font color='#36693c'><span class='italics'>Эльфы: </span></font>[SSround_end_statistics.species_elf]"
 	// REDMOON ADD END
-	shit += "<br><br><span class='bold'>∇--------------------∇</span>"
+	shit += "<br><span class='bold'>∇--------------------∇</span>"
 	to_chat(world, "[shit.Join()]")
 	return
 

--- a/modular_redmoon/code/modules/tgs/roundspoke.dm
+++ b/modular_redmoon/code/modules/tgs/roundspoke.dm
@@ -134,11 +134,11 @@
 		send2chat(random_message, "status")
 
 /world/proc/SendTGSRoundEnd()
-	var/count_of_joined_characters = SSticker.males + SSticker.females + SSticker.males_with_vagina + SSticker.females_with_penis
-	var/percent_of_males = PERCENT(SSticker.males/count_of_joined_characters)
-	var/percent_of_males_with_vagina = PERCENT(SSticker.males_with_vagina/count_of_joined_characters)
-	var/percent_of_females = PERCENT(SSticker.females/count_of_joined_characters)
-	var/percent_of_females_with_penis = PERCENT(SSticker.females_with_penis/count_of_joined_characters)
+	var/count_of_joined_characters = SSround_end_statistics.males + SSround_end_statistics.females + SSround_end_statistics.males_with_vagina + SSround_end_statistics.females_with_penis
+	var/percent_of_males = PERCENT(SSround_end_statistics.males/count_of_joined_characters)
+	var/percent_of_males_with_vagina = PERCENT(SSround_end_statistics.males_with_vagina/count_of_joined_characters)
+	var/percent_of_females = PERCENT(SSround_end_statistics.females/count_of_joined_characters)
+	var/percent_of_females_with_penis = PERCENT(SSround_end_statistics.females_with_penis/count_of_joined_characters)
 	var/datum/tgs_message_content/message = new ("...вот и сказочке конец.")
 	var/datum/tgs_chat_embed/structure/embed = new()
 	message.embed = embed
@@ -152,16 +152,39 @@
 	var/datum/tgs_chat_embed/field/triumphgained = new ("🏆 Триумфов получено: ", "[SSticker.tri_gained]")
 	var/datum/tgs_chat_embed/field/triumphslost = new (":woman_detective: Триумфов украдено: ","[SSticker.tri_lost*-1]")
 	var/datum/tgs_chat_embed/field/pleasures = new ("💦 Наслаждений: ", "[SSticker.cums]")
-	var/datum/tgs_chat_embed/field/violated_by_baotha = new (":smiling_imp: Осквернено Баотой: ", "[SSticker.violated_by_baotha.len]") // baotha_steals_triumphs
+	var/datum/tgs_chat_embed/field/violated_by_baotha = new (":smiling_imp: Осквернено Баотой: ", "[SSround_end_statistics.violated_by_baotha.len]") // baotha_steals_triumphs
 	var/datum/tgs_chat_embed/field/confessors = new (":orthodox_cross: Исповедники: ", "[GLOB.confessors.len]")
 	var/datum/tgs_chat_embed/field/families = new (":ring:Семьи: ", "[SSfamily.families.len]") // family_changes
-	var/datum/tgs_chat_embed/field/families_failed = new (":trollge: Пытались сформировать семью: ", "[length(SSfamily.family_candidates)]") // family_changes
-	var/datum/tgs_chat_embed/field/boys = new (":man_beard: Мужчины: ", "[SSticker.males] ([percent_of_males]%)")
-	var/datum/tgs_chat_embed/field/womens = new (":woman: Женщины: ", "[SSticker.females] ([percent_of_females]%)")
-	var/datum/tgs_chat_embed/field/femboys = new (":man: Кантбои: ", "[SSticker.males_with_vagina] ([percent_of_males_with_vagina]%)")
-	var/datum/tgs_chat_embed/field/futacocks = new (":woman_beard: Фута: ", "[SSticker.females_with_penis] ([percent_of_females_with_penis]%)")
+	var/datum/tgs_chat_embed/field/families_failed = new (":heart: Пытались сформировать семью: ", "[length(SSfamily.family_candidates)]") // family_changes
+	var/datum/tgs_chat_embed/field/men = new (":man_beard: Мужчины: ", "[SSround_end_statistics.males] ([percent_of_males]%)")
+	var/datum/tgs_chat_embed/field/women = new (":woman: Женщины: ", "[SSround_end_statistics.females] ([percent_of_females]%)")
+	var/datum/tgs_chat_embed/field/cuntboys = new (":man: Кантбои: ", "[SSround_end_statistics.males_with_vagina] ([percent_of_males_with_vagina]%)")
+	var/datum/tgs_chat_embed/field/futas = new (":woman_beard: Фута: ", "[SSround_end_statistics.females_with_penis] ([percent_of_females_with_penis]%)")
+	var/datum/tgs_chat_embed/field/species = new (":people_hugging: Расы: ", "\
+	Аасимары: [SSround_end_statistics.species_aasimar] | \
+	Аксиане: [SSround_end_statistics.species_axian] | \
+	Верминволки: [SSround_end_statistics.species_anthromorphsmall] | \
+	Вульпканин: [SSround_end_statistics.species_vulpkanin] | \
+	Гоблины: [SSround_end_statistics.species_goblinp] | \
+	Дварфы: [SSround_end_statistics.species_dwarf] | \
+	Дикари: [SSround_end_statistics.species_anthromorph] | \
+	Дракониды: [SSround_end_statistics.species_dracon] | \
+	Дроу: [SSround_end_statistics.species_drow] | \
+	Кобольды: [SSround_end_statistics.species_kobold] | \
+	Люпины: [SSround_end_statistics.species_lupian] | \
+	Люди: [SSround_end_statistics.species_humen] | \
+	Моли: [SSround_end_statistics.species_moth] | \
+	Полукровки: [SSround_end_statistics.species_demihuman] | \
+	Полуорки: [SSround_end_statistics.species_halfork] | \
+	Полуэльфы: [SSround_end_statistics.species_halfelf] | \
+	Сиссеане: [SSround_end_statistics.species_lizardfolk] | \
+	Табакси: [SSround_end_statistics.species_tabaxi] | \
+	Тифлинги: [SSround_end_statistics.species_tiefling] | \
+	Феи: [SSround_end_statistics.species_seelie] | \
+	Эльфы: [SSround_end_statistics.species_elf] | \
+	")
 
-	embed.fields = list(deaths, bloodspilled, triumphgained, triumphslost, pleasures, violated_by_baotha, confessors, families, families_failed, players, boys, womens, femboys, futacocks)
+	embed.fields = list(deaths, bloodspilled, triumphgained, triumphslost, pleasures, violated_by_baotha, confessors, families, families_failed, players, men, women, cuntboys, futas, species)
 
 	send2chat(message, "status")
 

--- a/modular_redmoon/modules/baotha_steals_triumphs/baotha_steals_triumphs.dm
+++ b/modular_redmoon/modules/baotha_steals_triumphs/baotha_steals_triumphs.dm
@@ -4,13 +4,13 @@
 	/// Количество совершенных действий. Нужно, чтобы баотиты за секунду не воровали чужие триумфы.
 	var/actions_made = 0
 
-/datum/controller/subsystem/ticker
+/datum/controller/subsystem/round_end_statistics
 	var/list/violated_by_baotha = list()
 
 /datum/sex_controller/proc/baotha_invitation(var/mob/living/baotha_cultist, var/mob/living/victim)
-	if(victim.real_name in SSticker.violated_by_baotha)
+	if(victim.real_name in SSround_end_statistics.violated_by_baotha)
 		return FALSE
-	SSticker.violated_by_baotha += victim.real_name
+	SSround_end_statistics.violated_by_baotha += victim.real_name
 	baotha_cultist.adjust_triumphs(1)
 	victim.adjust_triumphs(-1)
 	to_chat(victim, victim.client.prefs.be_russian ? span_userdanger("Я чувствую, как мою душу оскверняют!") : span_userdanger("I feel how my soul is being corrupted by them!"))
@@ -35,7 +35,7 @@
 		return FALSE
 	var/amount_to_change_nutrition = min(100, NUTRITION_LEVEL_FULL - baotha_cultist.nutrition)
 	var/amount_to_change_hydration = min(100, HYDRATION_LEVEL_FULL - baotha_cultist.nutrition)
-	if(victim.real_name in SSticker.violated_by_baotha)
+	if(victim.real_name in SSround_end_statistics.violated_by_baotha)
 		target.adjust_nutrition(-amount_to_change_nutrition)
 		target.adjust_hydration(-amount_to_change_hydration)
 		baotha_cultist.adjust_nutrition(amount_to_change_nutrition)

--- a/modular_redmoon/modules/stats_reports_with_gender_list/stats_reports_with_gender_lists.dm
+++ b/modular_redmoon/modules/stats_reports_with_gender_list/stats_reports_with_gender_lists.dm
@@ -1,20 +1,67 @@
 // Check comments with "start_reports_with_gender_lists" for all related code.
 
-/datum/controller/subsystem/ticker
+SUBSYSTEM_DEF(round_end_statistics)
+	name = "Round End Statistics"
+	init_order = INIT_ORDER_PATH
+	flags = SS_NO_FIRE
 	var/males = 0
 	var/females = 0
 	var/males_with_vagina = 0
 	var/females_with_penis = 0
+	var/species_aasimar = 0 // изначально делалось через массив, но массив красиво не отправить в IRC, потому множество переменных
+	var/species_anthromorph = 0
+	var/species_anthromorphsmall = 0
+	var/species_axian = 0
+	var/species_demihuman = 0
+	var/species_dracon = 0
+	var/species_drow = 0
+	var/species_dwarf = 0
+	var/species_elf = 0
+	var/species_goblinp = 0
+	var/species_halfelf = 0
+	var/species_halfork = 0
+	var/species_humen = 0 
+	var/species_kobold = 0
+	var/species_lizardfolk = 0
+	var/species_lupian = 0
+	var/species_moth = 0
+	var/species_seelie = 0
+	var/species_tabaxi = 0
+	var/species_tiefling = 0
+	var/species_vulpkanin = 0
 
 /mob/living/carbon/human/proc/add_gender_genitals_to_round_end_statistics()
 	switch(gender)
 		if(MALE)
 			if(getorganslot(ORGAN_SLOT_VAGINA))
-				SSticker.males_with_vagina++
+				SSround_end_statistics.males_with_vagina++
 			else
-				SSticker.males++
+				SSround_end_statistics.males++
 		if(FEMALE)
 			if(getorganslot(ORGAN_SLOT_PENIS))
-				SSticker.females_with_penis++
+				SSround_end_statistics.females_with_penis++
 			else
-				SSticker.females++
+				SSround_end_statistics.females++
+	switch(dna.species.type) // Так как благородные разработчики ратвуда не используют дефайны для названий рас, это самый безопасный вариант
+		if(/datum/species/aasimar) SSround_end_statistics.species_aasimar++
+		if(/datum/species/anthromorph) SSround_end_statistics.species_anthromorph++
+		if(/datum/species/anthromorphsmall) SSround_end_statistics.species_anthromorphsmall++
+		if(/datum/species/axian) SSround_end_statistics.species_axian++
+		if(/datum/species/demihuman) SSround_end_statistics.species_demihuman++
+		if(/datum/species/dracon) SSround_end_statistics.species_dracon++
+		if(/datum/species/dwarf/mountain) SSround_end_statistics.species_dwarf++
+		if(/datum/species/elf/dark) SSround_end_statistics.species_drow++
+		if(/datum/species/elf/wood) SSround_end_statistics.species_elf++
+		if(/datum/species/goblinp) SSround_end_statistics.species_goblinp++
+		if(/datum/species/halforc) SSround_end_statistics.species_halfork++
+		if(/datum/species/human/halfelf) SSround_end_statistics.species_halfelf++
+		if(/datum/species/human/northern) SSround_end_statistics.species_humen++
+		if(/datum/species/kobold) SSround_end_statistics.species_kobold++
+		if(/datum/species/lizardfolk) SSround_end_statistics.species_lizardfolk++
+		if(/datum/species/lupian) SSround_end_statistics.species_lupian++
+		if(/datum/species/moth) SSround_end_statistics.species_moth++
+		if(/datum/species/seelie) SSround_end_statistics.species_seelie++
+		if(/datum/species/tabaxi) SSround_end_statistics.species_tabaxi++
+		if(/datum/species/tieberian) SSround_end_statistics.species_tiefling++
+		if(/datum/species/vulpkanin) SSround_end_statistics.species_vulpkanin++
+		else send2irc("ERROR - REPORT TO DEV!", "Не удалось добавить расу в статистику конца раунда. [dna.species.type]")


### PR DESCRIPTION
# Описание

Добавлена статистика рас для конца раунда и IRC.

Изначально хотел сделать через массив, но в таком случае там каждый раз рандомился бы.

Алсо, мимоходом переведена статистика конца раунда в целом.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

Люди любят цифры. А разработчики на статистику ориентируются.

## Демонстрация изменений

![dreamseeker_Fv1qrgHNxV](https://github.com/user-attachments/assets/60098358-14f3-4204-9160-309f3b03a218)

