### PR TITLE
Бригантины снова в моде, облегчение и удорожание

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor/armor.dm
@@ -217,7 +217,7 @@
 	anvilrepair = /datum/skill/craft/blacksmithing
 	smeltresult = /obj/item/ingot/steel
 	equip_delay_self = 40
-	armor_class = ARMOR_CLASS_HEAVY
+	armor_class = ARMOR_CLASS_MEDIUM
 	w_class = WEIGHT_CLASS_BULKY
 	clothing_flags = CANT_SLEEP_IN
 	sleeved_detail = FALSE
@@ -283,7 +283,7 @@
 	armor = list("blunt" = 90, "slash" = 100, "stab" = 80, "bullet" = 100, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_TWIST)
 	max_integrity = 250
-	armor_class = ARMOR_CLASS_HEAVY
+	armor_class = ARMOR_CLASS_MEDIUM
 
 /obj/item/clothing/suit/roguetown/armor/brigandine/light
 	slot_flags = ITEM_SLOT_ARMOR
@@ -293,9 +293,10 @@
 	blocksound = SOFTHIT
 	body_parts_covered = CHEST|GROIN|VITALS
 	armor = list("blunt" = 60, "slash" = 70, "stab" = 70, "bullet" = 60, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	max_integrity = 200
 	smeltresult = /obj/item/ingot/iron
 	equip_delay_self = 40
-	armor_class = ARMOR_CLASS_MEDIUM
+	armor_class = ARMOR_CLASS_LIGHT
 	w_class = WEIGHT_CLASS_BULKY
 	clothing_flags = CANT_SLEEP_IN
 	resistance_flags = FIRE_PROOF

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -134,15 +134,15 @@
 	skill_level = 5
 
 /datum/anvil_recipe/armor/steel/coatplates
-	name = "Coat Of Plates (+1 Cloth)"
+	name = "Coat Of Plates (+1 steel) (+1 Cloth)"
 	req_bar = /obj/item/ingot/steel
-	additional_items = list(/obj/item/natural/cloth)
+	additional_items = list(/obj/item/ingot/steel, /obj/item/natural/cloth)
 	created_item = /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates
 
 /datum/anvil_recipe/armor/steel/brigandine
-	name = "Brigandine (+1 Steel) (+2 Cloth)"
+	name = "Brigandine (+2 Steel) (+2 Cloth)"
 	req_bar = /obj/item/ingot/steel
-	additional_items = list(/obj/item/ingot/steel, /obj/item/natural/cloth, /obj/item/natural/cloth)
+	additional_items = list(/obj/item/ingot/steel, /obj/item/ingot/steel, /obj/item/natural/cloth, /obj/item/natural/cloth)
 	created_item = /obj/item/clothing/suit/roguetown/armor/brigandine
 
 /datum/anvil_recipe/armor/steel/chaincoif


### PR DESCRIPTION
# Описание

<!-- Поменяй этот комментарий на краткое описание изменений, которые ты внёс -->
<!-- Если изменения косметические и ты уверен в их работоспособности, можно не проверять на локальном сервере. -->
<!-- Создавать предложку или багрепорт тоже необязательно. Если же они были, вставь ссылку на них. -->
- [X] Изменения были проверены на локальном сервере
- [X] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений - На данный момент бригантины почти не нужны, ибо имеют более удобных собратов в том же классе (в данном случае средней и тяжелой брони).

Brigantine - бригантина классическая, с геральдикой - перенесена в разряд средней брони, подорожала в производстве на один слиток для баланса, потому как для легких и прочных плит нужен более качественный металл.
**Раньше**: Класс тяжелый, 350 защиты, защищает руки и тело, легко оттеняется латной полуброней которая не требует искать ткань и стоит всего на слиток дороже, так еще и защищает лучше.
**Теперь:** Соперничает с кирасой за место на пьедестале средней брони, дороже, но лучше защищает и во дворце зауважают за геральдику, больше не защищает ноги, так как и не должна вовсе.

Coat of Plates - местная лорика сегментата - перенесена в класс средней брони как более дешевая альтернатива бригантине, стоит дешевле в слитках и ткани, за-то имеет на 100 очков прочности меньше.

**Раньше:** Неиспользуемая дешевая тяжелая броня, больше занимает кузнецов чем дает пользу, лучше уж купить себе кирасу, и то будет больше толку. 
**Теперь:** Соперник кирасы по стоимости, при том что защищает больше частей тела, уступает в 50 очках прочности. Лучший выбор для пехотинца помышляющего себя ветераном.

Lightweight Brigantine - Легкая бригантина. - Перенесена в класс легкой брони, теперь лучшая легкая броня которая не предоставляет слишком много защиты.
**Раньше:** Бесполезная средняя броня непонятно зачем созданная на случай дефицита железа, при имеющейся альтернативе в железной кирасе. 
**Теперь:** Вариант для легких пехотинцев защитить свою тушку от пробивающего урона, жизнеспособная броня которая существует не только что бы быть выброшенной теми кто получает ее раундстартом.


**_Почему это будет хорошо?_** - А я отвечу, в игре сейчас дефицит брони что не является тяжелой, легким бойцам вообще защититься в целом нечем, а бригантины как раз исторически и были этой срединной броней, что меньше стесняла чем панцири и латы, но была лучше чем кольчужки с гамбезонами.

<!-- Тут напиши причину, по которой твой пулл-реквест будет полезен для игры. -->

## Демонстрация изменений - я думаю все понятно объяснено, что тут уж демнострировать.

<!-- Можешь вставить тут видео или скриншоты изменений, если они будут полезны для проверяющего пулл-реквест.
	 Вставлять их можно Ctr+C, Ctr+V. -->

<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->
