### PR TITLE
Микрофиксы

### DIFF
--- a/modular_redmoon/modules/artificerandguns/runelockrecpies.dm
+++ b/modular_redmoon/modules/artificerandguns/runelockrecpies.dm
@@ -96,7 +96,7 @@
 	name = "Mechanised powderflask"
 	icon = 'modular_redmoon/modules/artificerandguns/runelock.dmi'
 	desc = "A neatly engineered gunpowder flask that compresses powder for size decreasement and cuts it for you so you dont have to measure it that much."
-	icon_state = "enguflask"
+	icon_state = "engiflask"
 	item_state = "powderflask"
 	slot_flags = SLOT_BELT_L | SLOT_BELT_R | ITEM_SLOT_NECK | ITEM_SLOT_HIP
 	w_class = WEIGHT_CLASS_SMALL

--- a/modular_redmoon/modules/brigandinerebalance/armor/armor.dm
+++ b/modular_redmoon/modules/brigandinerebalance/armor/armor.dm
@@ -1,6 +1,7 @@
 /obj/item/clothing/suit/roguetown/armor/brigandine
 	body_parts_covered = CHEST|GROIN|VITALS|ARMS
 	armor_class = ARMOR_CLASS_MEDIUM
+	armor = list("blunt" = 90, "slash" = 100, "stab" = 90, "bullet" = 100, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates
 	armor_class = ARMOR_CLASS_MEDIUM
@@ -8,3 +9,14 @@
 /obj/item/clothing/suit/roguetown/armor/brigandine/light
 	max_integrity = 200
 	armor_class = ARMOR_CLASS_LIGHT
+
+/obj/item/clothing/under/roguetown/splintlegs
+	armor_class = ARMOR_CLASS_LIGHT
+	max_integrity = 200
+
+/obj/item/clothing/wrists/roguetown/splintarms
+	max_integrity = 200
+	armor_class = ARMOR_CLASS_LIGHT
+
+/obj/item/clothing/suit/roguetown/armor/plate
+	body_parts_covered = CHEST|GROIN|VITALS|ARMS

--- a/modular_redmoon/modules/brigandinerebalance/armor/armor.dm
+++ b/modular_redmoon/modules/brigandinerebalance/armor/armor.dm
@@ -17,6 +17,3 @@
 /obj/item/clothing/wrists/roguetown/splintarms
 	max_integrity = 200
 	armor_class = ARMOR_CLASS_LIGHT
-
-/obj/item/clothing/suit/roguetown/armor/plate
-	body_parts_covered = CHEST|GROIN|VITALS|ARMS

--- a/modular_redmoon/modules/microfixes/microfixes.dm
+++ b/modular_redmoon/modules/microfixes/microfixes.dm
@@ -1,0 +1,11 @@
+/obj/item/lovepotion
+	grid_height = 32
+	grid_width = 32
+
+/obj/item/dildo
+	grid_height = 64
+	grid_width = 32
+
+/obj/item/chalk
+	grid_height = 64
+	grid_width = 32

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2325,6 +2325,7 @@
 #include "modular_redmoon\modules\lich_fixes\lich_fixes.dm"
 #include "modular_redmoon\modules\lovefiend_returns\love_fiend_returns.dm"
 #include "modular_redmoon\modules\memory_for_family_members\memory_for_family_members.dm"
+#include "modular_redmoon\modules\microfixes\microfixes.dm"
 #include "modular_redmoon\modules\minion_destroy\minion_destroy.dm"
 #include "modular_redmoon\modules\mob\living\carbon\human\examine.dm"
 #include "modular_redmoon\modules\mob\living\carbon\human\species_types\_species.dm"


### PR DESCRIPTION
# Фиксит штуки

Фикс классов брони у частей бригантины легкой

Бригантина защищает лучше чем свой легкий вариант

Наплечники полуброни перестали быть призрачными и защищают руки

Зелье приворота, дилдо, мелок имеют нормальный размер.

Улучшенная фляжка инженерка теперь снова имеет текстуру

<!-- Поменяй этот комментарий на краткое описание изменений, которые ты внёс -->
<!-- Если изменения косметические и ты уверен в их работоспособности, можно не проверять на локальном сервере. -->
<!-- Создавать предложку или багрепорт тоже необязательно. Если же они были, вставь ссылку на них. -->
- [X] Изменения были проверены на локальном сервере
- [X] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->