### PR TITLE
Make Parry Great Again

### DIFF
--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -185,7 +185,7 @@
 			// parrying while knocked down sucks ass
 			if(!(mobility_flags & MOBILITY_STAND))
 				prob2defend *= 0.65
-			prob2defend = clamp(prob2defend, 5, 90)
+			prob2defend = clamp(prob2defend, 5, 99)
 			if(src.client?.prefs.showrolls)
 				to_chat(src, span_info("Roll to parry... [prob2defend]%"))
 


### PR DESCRIPTION
# Твикает шанс на парирование до старых 99.
Модулярно это сделать увы невозможно. только так.
<!-- Поменяй этот комментарий на краткое описание изменений, которые ты внёс -->
<!-- Если изменения косметические и ты уверен в их работоспособности, можно не проверять на локальном сервере. -->
<!-- Создавать предложку или багрепорт тоже необязательно. Если же они были, вставь ссылку на них. -->
- [X] Изменения были проверены на локальном сервере
- [X] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений - С десятипроцентным шансом бомж с вилкой может попасть в легендарного мечника. Бред? Бред. Рушит баланс? Рушит. Не повлияет на бой между бойцами, но не даст всяким фермерам с 10 процентов шансем критовать всяких рыцарей.
