### PR TITLE
Бафф New Moon Spellblade

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/types/newmoon.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/types/newmoon.dm
@@ -56,7 +56,7 @@
 		H.mind.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/treatment, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, 1, TRUE)
-		H.mind.adjust_spellpoints(8) // REDMOON EDIT - добавлено 8 поинтов вместо 1, т.к. у него со старта книга говна и человеку нужно часа 2 дрочить ради получения 2-3 спеллов, а так получается умеренный старт
+		H.mind.adjust_spellpoints(6) // REDMOON EDIT - добавлено 8 поинтов вместо 1, т.к. у него со старта книга говна и человеку нужно часа 2 дрочить ради получения 2-3 спеллов, а так получается умеренный старт
 		if(H.age == AGE_OLD)
 			H.change_stat("intelligence", 4)
 			H.change_stat("strength", -2)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/types/newmoon.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/types/newmoon.dm
@@ -56,7 +56,7 @@
 		H.mind.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/treatment, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, 1, TRUE)
-		H.mind.adjust_spellpoints(1)
+		H.mind.adjust_spellpoints(8) // REDMOON EDIT - добавлено 8 поинтов вместо 1, т.к. у него со старта книга говна и человеку нужно часа 2 дрочить ради получения 2-3 спеллов, а так получается умеренный старт
 		if(H.age == AGE_OLD)
 			H.change_stat("intelligence", 4)
 			H.change_stat("strength", -2)


### PR DESCRIPTION
# Описание

Наемник Нока получает вместо 1 стартового очка для прокачки 8.

Why?

У чела:
1. Новичок чтения (он читает по слогам, это меньше чем у горожан).
2. Apprentice в аркане (следующая ступень после новичка) в аркане.
3. Худшая для прокачки книга на старте, которую может при желании собрать попрошайка из канавы, взяв светящийся камень

Чтобы начать качаться, ему нужно пройти целый квест и найти редкие предметы, используя шахтёров... И спустя примерно полтора часа, он сможет позволить себе 2 заклинания стартовых.

Я очень не люблю гринд и не хотел бы, чтобы игроки им занимались вместо участия в событиях раунда и взаимодействии.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера 

## Причина изменений

Spellblade как играбельный класс наемника без гринда в магию, которым занимаются остальные маги.

## Демонстрация изменений

![dreamseeker_q4tLrc98kB](https://github.com/user-attachments/assets/5f12f053-4553-498d-8910-9d765791119f)
![dreamseeker_eZUlfDD7zT](https://github.com/user-attachments/assets/d4350c70-a7a1-41e8-a5c8-b9de772b1604)
![dreamseeker_Ov7N4Ok8Ix](https://github.com/user-attachments/assets/34ae949c-c949-4067-8bf9-9caf3e4f2369)
![dreamseeker_CkCCIGkz3P](https://github.com/user-attachments/assets/904a4ecc-2ddc-4db8-b7cd-1d4a18a46b2b)
![dreamseeker_0q1lWkQdLQ](https://github.com/user-attachments/assets/e98a3d4b-e270-4b34-8482-02197b1e593e)
![dreamseeker_ygrldAfC2G](https://github.com/user-attachments/assets/88095f4f-a1fc-42e0-bbce-fc3bc14f5204)
