### PR TITLE
Desert rider bladecaster rebalance

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/types/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/types/desertrider.dm
@@ -93,13 +93,11 @@
 			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/treatment, 1, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/treatment, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/knives, 4, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE)
@@ -109,14 +107,22 @@
 			H.change_stat("intelligence", 3)
 			H.change_stat("speed", 3)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
-			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/push_spell)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/lightninglure)
 			armor = /obj/item/clothing/suit/roguetown/shirt/robe/magered
-			l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/parrying
-			beltl = /obj/item/rogueweapon/whip
-			pants = /obj/item/clothing/under/roguetown/trou/leather
-
 			H.grant_language(/datum/language/celestial)
 			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
+			pants = /obj/item/clothing/under/roguetown/trou/leather
+			var/weapons = list("Shamshir","Whips and Knives",)
+			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+			H.set_blindness(0)
+			switch(weapon_choice)
+				if("Shamshir")
+					backl = /obj/item/rogueweapon/sword/long/rider
+					H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
+				if("Whips and Knives")
+					beltl = /obj/item/rogueweapon/whip
+					l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/parrying
+					H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 1, TRUE)
 
 	shoes = /obj/item/clothing/shoes/roguetown/armor/shalal
 	head = /obj/item/clothing/head/roguetown/roguehood/shalal

--- a/code/modules/jobs/job_types/roguetown/mercenaries/types/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/types/desertrider.dm
@@ -98,6 +98,7 @@
 			H.mind.adjust_skillrank(/datum/skill/misc/treatment, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/knives, 4, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE)


### PR DESCRIPTION
Ещё чуть-чуть подбалансировал подкласс Блейдкастера у пустынных наёмников.

Во первых дал ему выбор между саблей и кнутом (который я проебал по дурости).
Во вторых убрал у него чтение, т.к. новую магию он не изучит энивей.
В третьих +1 атлетика и +1 лечение.
В четвёртых изменил заклинание на отталкивание, на заклинание цепной молнии, поскольку я не играю на магах и не разбираюсь в этом, человек, который успел уже побегать на этом классе, аргументированно объяснил и показал, почему это стоит менять. Заклинания стоят одинаково по очкам.