### PR TITLE
Фикс для сохранения статов мигрантов после изъяна плохого зрения

### DIFF
--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -127,6 +127,10 @@ GLOBAL_LIST_INIT(character_flaws, list(
 /datum/charflaw/badsight/flaw_on_life(mob/user)
 	if(!ishuman(user))
 		return
+	// REDMOON ADD START - персонажи-мигранты. выбирающие класс, по окончанию выбора записывают свои статы в стартовые. Это приводит к тому, что дебаф от этого перка становится стартовым. Фиксим этот баг
+	if(HAS_TRAIT_FROM(user, TRAIT_PACIFISM, HUGBOX_TRAIT))
+		return
+	// REDMOON ADD END
 	var/mob/living/carbon/human/H = user
 	if(H.wear_mask)
 		if(isclothing(H.wear_mask))


### PR DESCRIPTION
# Описание

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера 

## Причина изменений

Фиксы багов

## Демонстрация изменений

![dreamseeker_4OY1dMY3VK](https://github.com/user-attachments/assets/663335d5-d831-44be-ba25-9c002240bb60)
