### PR TITLE
Исправление цен на оружие раундстартом

### DIFF
--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -36,7 +36,7 @@ SUBSYSTEM_DEF(treasury)
 
 /datum/controller/subsystem/treasury/Initialize()
 	treasury_value = rand(800,1500)
-	queens_tax = rand(0.06, 0.13) // REDMOON EDIT - prices_fix - снижен налог гильдии - WAS pick(0.09, 0.15, 0.21, 0.30)
+	queens_tax = rand(5, 11)/100 // REDMOON EDIT - prices_fix - снижен налог гильдии - WAS pick(0.09, 0.15, 0.21, 0.30)
 	
 	for(var/path in subtypesof(/datum/roguestock/bounty))
 		var/datum/D = new path

--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -36,8 +36,8 @@ SUBSYSTEM_DEF(treasury)
 
 /datum/controller/subsystem/treasury/Initialize()
 	treasury_value = rand(800,1500)
-	queens_tax = pick(0.09, 0.15, 0.21, 0.30)
-
+	queens_tax = rand(0.06, 0.13) // REDMOON EDIT - prices_fix - снижен налог гильдии - WAS pick(0.09, 0.15, 0.21, 0.30)
+	
 	for(var/path in subtypesof(/datum/roguestock/bounty))
 		var/datum/D = new path
 		stockpile_datums += D

--- a/code/modules/farming/bin.dm
+++ b/code/modules/farming/bin.dm
@@ -171,12 +171,15 @@
 			if(!isturf(used_turf))
 				used_turf = get_turf(src)
 			var/datum/anvil_recipe/R = T.hingot.currecipe
+			var/obj/item/created_item // REDMOON ADD - prices_fix
 			if(islist(R.created_item))
 				var/list/L = R.created_item
 				for(var/IT in L)
-					new IT(used_turf)
+					created_item = new IT(used_turf) // REDMOON EDIT - prices_fix - добавлено created_item =
+					created_item.Get_Anvil_Production_Sellprice(R) // REDMOON ADD - prices_fix
 			else
-				new R.created_item(used_turf)
+				created_item = new R.created_item(used_turf) // REDMOON EDIT - prices_fix - добавлено created_item =
+				created_item.Get_Anvil_Production_Sellprice(R) // REDMOON ADD - prices_fix
 			playsound(src,pick('sound/items/quench_barrel1.ogg','sound/items/quench_barrel2.ogg'), 100, FALSE)
 			QDEL_NULL(T.hingot)
 			T.update_icon()

--- a/modular_redmoon/modules/prices_fix/prices_fix.dm
+++ b/modular_redmoon/modules/prices_fix/prices_fix.dm
@@ -21,13 +21,10 @@
  */
 
 /obj/item/rogueweapon/mace
-	sellprice = 10
+	sellprice = 20
 
 /obj/item/rogueweapon/mace/church
 	sellprice = 50 // Уникальное
-
-/obj/item/rogueweapon/mace/cudgel
-	sellprice = 10
 
 /obj/item/rogueweapon/mace/wsword // Деревянный меч
 	sellprice = 2
@@ -138,9 +135,6 @@
 /obj/item/rogueweapon/sword
 	sellprice = 10 
 
-/obj/item/rogueweapon/sword/decorated
-	sellprice = 50 
-
 /obj/item/rogueweapon/sword/short
 	sellprice = 20 // Сталь 
 
@@ -171,14 +165,8 @@
 /obj/item/rogueweapon/sword/sabre
 	sellprice = 20
 
-/obj/item/rogueweapon/sword/sabre/dec
-	sellprice = 100
-
 /obj/item/rogueweapon/sword/rapier
 	sellprice = 20
-
-/obj/item/rogueweapon/sword/rapier/dec
-	sellprice = 60 
 
 /obj/item/rogueweapon/sword/cutlass
 	sellprice = 20 

--- a/modular_redmoon/modules/prices_fix/prices_fix.dm
+++ b/modular_redmoon/modules/prices_fix/prices_fix.dm
@@ -1,0 +1,283 @@
+// Исказать связанное через "prices_fix"
+
+/*
+ * ТОПОРЫ
+ */
+
+/obj/item/rogueweapon/stoneaxe/battle
+	sellprice = 20 // цена у оружия раундстартом низкая, а у произведенного в кузне после начала раунда уже выше
+
+/obj/item/rogueweapon/stoneaxe/woodcut
+	sellprice = 10
+
+/obj/item/rogueweapon/stoneaxe/woodcut/steel
+	sellprice = 20
+
+/obj/item/rogueweapon/stoneaxe/handaxe
+	sellprice = 10
+
+/*
+ * БУЛАВЫ
+ */
+
+/obj/item/rogueweapon/mace
+	sellprice = 10
+
+/obj/item/rogueweapon/mace/church
+	sellprice = 50 // Уникальное
+
+/obj/item/rogueweapon/mace/cudgel
+	sellprice = 10
+
+/obj/item/rogueweapon/mace/wsword // Деревянный меч
+	sellprice = 2
+
+/obj/item/rogueweapon/mace/steel
+	sellprice = 20
+
+/obj/item/rogueweapon/mace/warhammer/steel
+	sellprice = 20
+
+/obj/item/rogueweapon/mace/goden/steel
+	sellprice = 20 
+
+/obj/item/rogueweapon/mace/stunmace
+	sellprice = 40 // Уникальное
+
+/*
+ * ДРУГОЕ
+ */
+
+/obj/item/rogueweapon/flail
+	sellprice = 10 
+
+/obj/item/rogueweapon/flail/sflail
+	sellprice = 20 
+
+/obj/item/rogueweapon/whip
+	sellprice = 10 
+
+/obj/item/rogueweapon/whip/antique
+	sellprice = 100 // Уникальное
+
+/obj/item/rogueweapon/huntingknife
+	sellprice = 5 // Повсеместно встречается, к сожалению
+
+/obj/item/rogueweapon/huntingknife/cleaver
+	sellprice = 20 
+
+/obj/item/rogueweapon/huntingknife/scissors
+	sellprice = 10
+
+/obj/item/rogueweapon/huntingknife/scissors/steel
+	sellprice = 20 
+
+/obj/item/rogueweapon/huntingknife/idagger
+	sellprice = 10 
+
+/obj/item/rogueweapon/huntingknife/idagger/steel
+	sellprice = 20
+
+/obj/item/rogueweapon/huntingknife/idagger/silver
+	sellprice = 30 
+
+/obj/item/rogueweapon/huntingknife/elvish
+	sellprice = 30 // серебро
+
+/obj/item/rogueweapon/huntingknife/elvish/drow
+	sellprice = 50 // Уникальное
+
+/obj/item/rogueweapon/woodstaff/aries
+	sellprice = 200 // Уникальное
+
+/*
+ * КОПЬЯ
+ */
+
+/obj/item/rogueweapon/spear
+	sellprice = 10 
+
+/obj/item/rogueweapon/spear/billhook
+	sellprice = 20 
+
+/obj/item/rogueweapon/spear/stone
+	sellprice = 2
+
+/obj/item/rogueweapon/halberd
+	sellprice = 35 // 2 стали
+
+/obj/item/rogueweapon/halberd/bardiche
+	sellprice = 20 // 2 железа
+
+/obj/item/rogueweapon/eaglebeak
+	sellprice = 35 // 2 стали
+
+/obj/item/rogueweapon/eaglebeak/lucerne
+	sellprice = 30 // сталь и железо
+
+/obj/item/rogueweapon/spear/bronze
+	sellprice = 20 
+
+/obj/item/rogueweapon/greatsword
+	sellprice = 60 // 3 стали
+
+/obj/item/rogueweapon/greatsword/zwei
+	sellprice = 30 // 3 железа
+
+/obj/item/rogueweapon/estoc
+	sellprice = 60 // 3 стали
+
+/obj/item/rogueweapon/lordscepter
+	sellprice = 200 // Уникальное 
+
+
+
+/obj/item/rogueweapon/katar
+	sellprice = 20 // Сталь
+
+/obj/item/rogueweapon/sword
+	sellprice = 10 
+
+/obj/item/rogueweapon/sword/decorated
+	sellprice = 50 
+
+/obj/item/rogueweapon/sword/short
+	sellprice = 20 // Сталь 
+
+/obj/item/rogueweapon/sword/long
+	sellprice = 40
+
+/obj/item/rogueweapon/sword/long/heirloom
+	sellprice = 100 // Фамильный меч
+
+/obj/item/rogueweapon/sword/long/rider
+	sellprice = 40
+
+/obj/item/rogueweapon/sword/long/marlin
+	sellprice = 150 // Уникальное 
+
+/obj/item/rogueweapon/sword/long/exe
+	sellprice = 50
+
+/obj/item/rogueweapon/sword/long/exe/cloth
+	sellprice = 150 // Терминус Эст 
+
+/obj/item/rogueweapon/sword/iron
+	sellprice = 10 
+
+/obj/item/rogueweapon/sword/iron/messer/steel
+	sellprice = 20 
+
+/obj/item/rogueweapon/sword/sabre
+	sellprice = 20
+
+/obj/item/rogueweapon/sword/sabre/dec
+	sellprice = 100
+
+/obj/item/rogueweapon/sword/rapier
+	sellprice = 20
+
+/obj/item/rogueweapon/sword/rapier/dec
+	sellprice = 60 
+
+/obj/item/rogueweapon/sword/cutlass
+	sellprice = 20 
+
+/obj/item/rogueweapon/sword/sabre/elf
+	sellprice = 60 // 2 серебра 
+
+/obj/item/rogueweapon/sword/gladius
+	sellprice = 20 
+
+/obj/item/rogueweapon/sword/sabre_freeze
+	sellprice = 80 // Уникальное
+
+
+
+/obj/item/rogueweapon/shield
+
+/obj/item/rogueweapon/shield/wood
+	sellprice = 10 
+
+/obj/item/rogueweapon/shield/tower
+	sellprice = 20 
+
+
+/obj/item/rogueweapon/thresher
+	sellprice = 10 
+
+/obj/item/rogueweapon/thresher/wflail
+	sellprice = 15 
+
+/obj/item/rogueweapon/sickle
+	sellprice = 10 
+
+/obj/item/rogueweapon/hoe
+	sellprice = 10 
+
+/obj/item/rogueweapon/pitchfork
+	sellprice = 10 
+
+
+/obj/item/rogueweapon/handsaw
+	sellprice = 20 
+
+/obj/item/rogueweapon/chisel
+	sellprice = 20 
+
+/obj/item/rogueweapon/hammer
+	sellprice = 10 
+
+/obj/item/rogueweapon/hammer/steel
+	sellprice = 20 
+
+/obj/item/rogueweapon/hammer/blacksteel
+	sellprice = 30 
+
+/obj/item/rogueweapon/hammer/wood
+	sellprice = 5 
+
+/obj/item/rogueweapon/tongs
+	sellprice = 20 
+
+/obj/item/rogueweapon/tongs/blacksteel
+	sellprice = 40 
+
+/obj/item/rogueweapon/shovel
+	sellprice = 10 
+
+/obj/item/rogueweapon/shovel/small
+	sellprice = 5 
+
+
+/obj/item/rogueweapon/huntingknife/idagger/silver/arcyne
+	sellprice = 50
+
+
+
+/obj/item/rogueweapon/pick
+	sellprice = 10 
+
+/obj/item/rogueweapon/pick/steel
+	sellprice = 20 
+
+/obj/item/rogueweapon/pick/blacksteel
+	sellprice = 30 
+
+/obj/item/rogueweapon/pick/drill
+	sellprice = 50 
+
+/obj/item/rogueweapon/surgery
+	sellprice = 10 
+
+/obj/item/rogueweapon/whip/antique/psywhip
+	sellprice = 100 
+
+/obj/item/rogueweapon/huntingknife/throwingknife
+	sellprice = 10 
+
+/obj/item/rogueweapon/huntingknife/throwingknife/steel
+	sellprice = 20 
+
+/obj/item/rogueweapon/huntingknife/throwingknife/psydon
+	sellprice = 30 

--- a/modular_redmoon/modules/prices_fix/prices_fix_recipes.dm
+++ b/modular_redmoon/modules/prices_fix/prices_fix_recipes.dm
@@ -1,0 +1,104 @@
+
+/datum/anvil_recipe
+	var/sellprice = 0
+
+/obj/item/proc/Get_Anvil_Production_Sellprice(datum/anvil_recipe/anvil_recipe)
+	if(anvil_recipe.sellprice)
+		sellprice = anvil_recipe.sellprice
+		randomize_price()
+
+/// IRON 
+
+/datum/anvil_recipe/weapons/iron
+	sellprice = 20
+
+/datum/anvil_recipe/weapons/iron/bardiche
+	sellprice = 40
+
+/datum/anvil_recipe/weapons/iron/zweihander
+	sellprice = 60
+
+/// STEEL
+
+/datum/anvil_recipe/weapons/steel
+	sellprice = 30
+
+/datum/anvil_recipe/weapons/steel/bastardsword
+	sellprice = 60
+
+/datum/anvil_recipe/weapons/steel/battleaxe
+	sellprice = 60
+
+/datum/anvil_recipe/weapons/steel/mace
+	sellprice = 60
+
+/datum/anvil_recipe/weapons/steel/warhammer
+	sellprice = 60
+
+/datum/anvil_recipe/weapons/steel/langesmesser
+	sellprice = 60
+
+/datum/anvil_recipe/weapons/steel/estoc
+	sellprice = 90
+
+/datum/anvil_recipe/weapons/steel/greatsword
+	sellprice = 90
+
+/datum/anvil_recipe/weapons/steel/lucerne
+	sellprice = 50
+
+/datum/anvil_recipe/weapons/steel/halberd
+	sellprice = 60
+
+/datum/anvil_recipe/weapons/steel/eaglebeak
+	sellprice = 60
+
+/datum/anvil_recipe/weapons/steel/execution
+	sellprice = 50
+
+/// SILVER 
+
+/datum/anvil_recipe/weapons/silver
+	sellprice = 60
+
+/// GOLD
+
+/datum/anvil_recipe/weapons/decsword/steel
+	sellprice = 140
+
+/datum/anvil_recipe/weapons/decsword
+	sellprice = 140
+
+/datum/anvil_recipe/weapons/decsaber/steel
+	sellprice = 140
+
+/datum/anvil_recipe/weapons/decsaber
+	sellprice = 140
+
+/datum/anvil_recipe/weapons/decrapier/steel
+	sellprice = 140
+
+/datum/anvil_recipe/weapons/decrapier
+	sellprice = 140
+
+/datum/anvil_recipe/weapons/terminus
+	sellprice = 250
+
+// BRONZE
+
+/datum/anvil_recipe/weapons/gladius
+	sellprice = 20
+
+/datum/anvil_recipe/weapons/bronze/spear
+	sellprice = 40
+
+/// SHIELDS
+
+/datum/anvil_recipe/weapons/steel/kiteshield
+	sellprice = 80
+
+/datum/anvil_recipe/weapons/iron/towershield
+	sellprice = 20
+
+/datum/anvil_recipe/weapons/steel/buckler
+	sellprice = 30

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2408,6 +2408,7 @@
 #include "modular_redmoon\modules\mob\living\carbon\human\species_types\roguetown\vulpkanin.dm"
 #include "modular_redmoon\modules\notongue\notongue.dm"
 #include "modular_redmoon\modules\prices_fix\prices_fix.dm"
+#include "modular_redmoon\modules\prices_fix\prices_fix_recipes.dm"
 #include "modular_redmoon\modules\ranged_weapon_balancing\ranged_weapon_balancing.dm"
 #include "modular_redmoon\modules\round_end_vote_for_people\round_end_vote_for_people.dm"
 #include "modular_redmoon\modules\rumors\rumors.dm"

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2407,6 +2407,7 @@
 #include "modular_redmoon\modules\mob\living\carbon\human\species_types\roguetown\tiefling.dm"
 #include "modular_redmoon\modules\mob\living\carbon\human\species_types\roguetown\vulpkanin.dm"
 #include "modular_redmoon\modules\notongue\notongue.dm"
+#include "modular_redmoon\modules\prices_fix\prices_fix.dm"
 #include "modular_redmoon\modules\ranged_weapon_balancing\ranged_weapon_balancing.dm"
 #include "modular_redmoon\modules\round_end_vote_for_people\round_end_vote_for_people.dm"
 #include "modular_redmoon\modules\rumors\rumors.dm"


### PR DESCRIPTION
# Описание

- Добавлена цена на практически всё оружие.  Она ниже цены производства. 
- Но, оружие, которое куёт кузнец, как минимум окупает цену своего производства для возможности нормальной продажи торговцу. Стальное и золотое лучше.
- В этом же ПР торговый налог гильдии снижен.

- [x] Этот пулл-реквест готов к тест-мерджу.

## Причина изменений

https://discord.com/channels/1325992381899866183/1359157625002000476

## Демонстрация изменений

-