### PR TITLE
Фикс прыжка на 6 тайлов, добавление непробиваемой обычными средствами стены в основание замка

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -622,7 +622,8 @@
 
 		if (user_momentum)
 			//first lets add that momentum to range.
-			range *= (user_momentum / speed) + 1
+			if(!isliving(src))
+				range *= (user_momentum / speed) + 1
 			//then lets add it to speed
 			speed += user_momentum
 			if (speed <= 0)

--- a/modular_redmoon/modules/unbreakable_castle_underwalls/unbreakable_castle_underwalls.dm
+++ b/modular_redmoon/modules/unbreakable_castle_underwalls/unbreakable_castle_underwalls.dm
@@ -1,0 +1,32 @@
+#define CASTLE_NORTH_OUTER_WALLS_Y 403 // НУЖНО ОБСЛУЖИВАТЬ ПРИ ИЗМЕНЕНИИ КАРТЫ! Стена на сервере подземки замка, через которую не должно быть возможно прокопаться
+#define CASTLE_SOUTH_OUTER_WALLS_Y_END 360 // НУЖНО ОБСЛУЖИВАТЬ ПРИ ИЗМЕНЕНИИ КАРТЫ! Конец стены на юге подземки замка
+#define CASTLE_SOUTH_OUTER_WALLS_Y 358 // НУЖНО ОБСЛУЖИВАТЬ ПРИ ИЗМЕНЕНИИ КАРТЫ! Начало стены на юге подземки замка
+#define CASTLE_RIGHT_OUTER_WALLS_X 188 // НУЖНО ОБСЛУЖИВАТЬ ПРИ ИЗМЕНЕНИИ КАРТЫ! Крайняя стена на востоке подземки замка
+
+/turf/closed/mineral/rogue/attackby(obj/item/I, mob/user, params)
+	..()
+	var/too_hard = FALSE
+
+	if(y >= CASTLE_SOUTH_OUTER_WALLS_Y) // Проверяются только тайлы начала южной стены и выше
+		if(is_station_level(z))
+			if(y <= CASTLE_SOUTH_OUTER_WALLS_Y_END) // Запрет на выкапывание южной стены
+				too_hard = TRUE
+
+			else if(y == CASTLE_NORTH_OUTER_WALLS_Y) // Запрет на выкапывание северной стены
+				too_hard = TRUE
+
+			else if(x == CASTLE_RIGHT_OUTER_WALLS_X) // Запрет на выкапывание восочной стены
+				too_hard = TRUE
+
+	if(too_hard)
+		to_chat(user, span_warning("CASTLE UNDERWALLS ARE TOO HARD TO BE BROKEN!"))
+		turf_integrity = max_integrity
+
+// Часть южной стены из камня, а не из породы
+/turf/closed/wall/mineral/rogue/attackby(obj/item/I, mob/user, params)
+	..()
+	if(y >= CASTLE_SOUTH_OUTER_WALLS_Y) // Проверяются только тайлы начала южной стены и выше
+		if(is_station_level(z))
+			if(y <= CASTLE_SOUTH_OUTER_WALLS_Y_END) // Запрет на выкапывание южной стены
+				to_chat(user, span_warning("CASTLE UNDERWALLS ARE TOO HARD TO BE BROKEN!"))
+				turf_integrity = max_integrity

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2465,6 +2465,7 @@
 #include "modular_redmoon\modules\tetris\waterskin.dm"
 #include "modular_redmoon\modules\tetris\weaponry.dm"
 #include "modular_redmoon\modules\tetris\wrists.dm"
+#include "modular_redmoon\modules\unbreakable_castle_underwalls\unbreakable_castle_underwalls.dm"
 #include "modular_redmoon\modules\venicle\baneblade.dm"
 #include "modular_redmoon\modules\venicle\funny_movement.dm"
 // END_INCLUDE


### PR DESCRIPTION
# Описание

- Стена в основании замка больше не может быть пробита обычными средствами (например, киркой).
- Персонажи больше не могут прыгать дальше, чем то задумано игрой (там происходило перемножение ускорения на дальность).

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера 

## Причина изменений

Фиксим баги.
Подкопы - рак.

## Демонстрация изменений

-