### PR TITLE
Исправление выдачи ском-колец многим ролям и рекрутинга авангарда

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/bogmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogmaster.dm
@@ -93,4 +93,5 @@
 	. = ..()
 	if(!.)
 		return
+	recruit.advjob = new_role // REDMOON ADD - исправляет, что при выдачи роли авангарда у человека в описании пишется только раса
 	recruit.verbs |= /mob/proc/haltyell

--- a/modular_redmoon/modules/scomrings/rings/startthings.dm
+++ b/modular_redmoon/modules/scomrings/rings/startthings.dm
@@ -1,43 +1,43 @@
 /datum/outfit/job/roguetown/bogmaster/pre_equip(mob/living/carbon/human/H)
+	..()
 	id = /obj/item/scomstone_rk/bad/garrison
-	. = ..()
 
 /datum/outfit/job/roguetown/knight/pre_equip(mob/living/carbon/human/H)
+	..()
 	id = /obj/item/scomstone_rk/bad/garrison
-	. = ..()
 
 /datum/outfit/job/roguetown/lord/pre_equip(mob/living/carbon/human/H)
+	..()
 	backr = /obj/item/storage/backpack/rogue/satchel/ruler/
-	. = ..()
 
 /datum/outfit/job/roguetown/captain/pre_equip(mob/living/carbon/human/H)
+	..()
 	id = /obj/item/scomstone_rk/garrison
-	. = ..()
 
 /datum/outfit/job/roguetown/sheriff/pre_equip(mob/living/carbon/human/H)
+	..()
 	id = /obj/item/scomstone_rk/bad/garrison
-	. = ..()
 
 /datum/outfit/job/roguetown/marshal/pre_equip(mob/living/carbon/human/H)
+	..()
 	id = /obj/item/scomstone_rk/garrison
-	. = ..()
 
 /datum/outfit/job/roguetown/steward/pre_equip(mob/living/carbon/human/H)
+	..()
 	id = /obj/item/scomstone_rk/garrison
-	. = ..()
 
 /datum/outfit/job/roguetown/hand/pre_equip(mob/living/carbon/human/H)
+	..()
 	id = /obj/item/scomstone_rk/garrison
-	. = ..()
 
 /datum/outfit/job/roguetown/prince/bookworm/pre_equip(mob/living/carbon/human/H)
+	..()
 	id = /obj/item/scomstone_rk
-	. = ..()
 
 /datum/outfit/job/roguetown/prince/militant/pre_equip(mob/living/carbon/human/H)
+	..()
 	id = /obj/item/scomstone_rk/garrison
-	. = ..()
 
 /datum/outfit/job/roguetown/prince/sheltered/pre_equip(mob/living/carbon/human/H)
+	..()
 	id = /obj/item/scomstone_rk/bad
-	. = ..()

--- a/modular_redmoon/modules/scomrings/rings/startthings.dm
+++ b/modular_redmoon/modules/scomrings/rings/startthings.dm
@@ -19,7 +19,7 @@
 	. = ..()
 
 /datum/outfit/job/roguetown/marshal/pre_equip(mob/living/carbon/human/H)
-	id = /obj/item/scomstone_rk/bad/garrison
+	id = /obj/item/scomstone_rk/garrison
 	. = ..()
 
 /datum/outfit/job/roguetown/steward/pre_equip(mob/living/carbon/human/H)


### PR DESCRIPTION
# Описание

- При рекрутировании авангарда, не писалась новая должность у призывника. Исправлено.
- Из-за неправильной постановки ..(), id при выдаче ском-колец переписывался. Исправлено.

- [x] Этот пулл-реквест готов к тест-мерджу.

## Причина изменений

фиксы

## Демонстрация изменений

-