### PR TITLE
Статистика профессий

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -326,6 +326,7 @@
 			round_occupations += "<font color='#b18254'><span class='italics'>[target_job.title]</span></font> - [target_job.current_positions]<br>"
 	shit += round_occupations
 	// REDMOON ADD END
+	shit += "<br><span class='bold'>∇--------------------∇</span>"
 	to_chat(world, "[shit.Join()]")
 	return
 

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -317,8 +317,15 @@
 	if(SSround_end_statistics.species_tiefling)			shit += "<br><font color='#36693c'><span class='italics'>Тифлинги: </span></font>[SSround_end_statistics.species_tiefling]"
 	if(SSround_end_statistics.species_seelie)			shit += "<br><font color='#36693c'><span class='italics'>Феи: </span></font>[SSround_end_statistics.species_seelie]"
 	if(SSround_end_statistics.species_elf)				shit += "<br><font color='#36693c'><span class='italics'>Эльфы: </span></font>[SSround_end_statistics.species_elf]"
+	// jobs_statistics
+	shit += "<br><span class='bold'>⇕--------------------⇕</span>"
+	shit += "<br><font color='#9b6937'><span class='bold'>Псайдон распорядился, чтоб был у каждого свой удел:</span></font> "
+	var/round_occupations = "<br>"
+	for(var/datum/job/roguetown/target_job in SSjob.occupations)
+		if(target_job.current_positions > 0)
+			round_occupations += "<font color='#b18254'><span class='italics'>[target_job.title]</span></font> - [target_job.current_positions]<br>"
+	shit += round_occupations
 	// REDMOON ADD END
-	shit += "<br><span class='bold'>∇--------------------∇</span>"
 	to_chat(world, "[shit.Join()]")
 	return
 

--- a/modular_redmoon/code/modules/tgs/roundspoke.dm
+++ b/modular_redmoon/code/modules/tgs/roundspoke.dm
@@ -184,8 +184,13 @@
 	Феи: [SSround_end_statistics.species_seelie] | \
 	Эльфы: [SSround_end_statistics.species_elf] | \
 	")
+	var/round_occupations = ""
+	for(var/datum/job/roguetown/target_job in SSjob.occupations)
+		if(target_job.current_positions > 0)
+			round_occupations += "[target_job.title] - [target_job.current_positions] | "
+	var/datum/tgs_chat_embed/field/jobs = new (":briefcase: Уделы: ", round_occupations)
 
-	embed.fields = list(deaths, bloodspilled, triumphgained, triumphslost, pleasures, violated_by_baotha, confessors, families, families_failed, players, men, women, cuntboys, futas, species)
+	embed.fields = list(deaths, bloodspilled, triumphgained, triumphslost, pleasures, violated_by_baotha, confessors, families, families_failed, players, men, women, cuntboys, futas, species, jobs)
 
 	send2chat(message, "status")
 


### PR DESCRIPTION
# Описание

Добавление статистики профессий в экран конца раунда и в отчёт в дискорд.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

На основе точной статистики можно делать выводы и более точно изменять игру.

## Демонстрация изменений

+