### PR TITLE
Работа над Uncommend, фикс неправильного сохранения префов и преф на отключение звуков и эффектов стресса

### DIFF
--- a/code/__REDFINES/prefereces.dm
+++ b/code/__REDFINES/prefereces.dm
@@ -1,0 +1,2 @@
+// Redmoon Preference toggles
+#define STRESS_EFFECTS			(1<<0)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1180,11 +1180,11 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		else
 			to_chat(src,"You can't commend yourself.")
 		return
-	if(!can_commend(forced))
-		return
 	if(theykey)
 		// REDMOON REMOVAL - перенесено вниз - WAS: prefs.commendedsomeone = TRUE 
 		if(action == "Похвалить" || action == "Commend")
+			if(!can_commend(forced))
+				return
 			if(add_commend(theykey, ckey))
 				to_chat(src,"[selection] получит похвалу (или даже \"спасибо\", если это первый commend).")
 				prefs.commendedsomeone = TRUE // REDMOON ADD
@@ -1194,6 +1194,8 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 			message_admins("[ckey] commends [theykey].")
 			REDMOON REMOVAL END */
 		else if(action == "Поругать" || action == "Uncommend")
+			if(!can_uncommend(forced))
+				return
 			if(get_playerquality(key) < 0) // Игроки с отрицательным PQ не могут снижать чужое PQ
 				to_chat(src, span_danger("У тебя слишком плохая репутация, чтобы обвинять кого-то."))
 				return FALSE
@@ -1201,8 +1203,8 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 				to_chat(src, span_danger("Подожди конца раунда и лучше осмысли ситуацию."))
 				return FALSE
 			if(add_uncommend(theykey, ckey))
-				to_chat(src,"[selection] получит негативный комментарий (или даже -PQ, если это первый uncommend).")
-				prefs.commendedsomeone = TRUE // REDMOON ADD
+				to_chat(src,"[selection] получит негативный комментарий, видимый только ему (без снятия PQ).")
+				prefs.negative_commented_someone = TRUE // REDMOON ADD
 	return
 
 // Handles notifying funeralized players on login, or forcing them back to lobby, depending on configs. Called on /client/New().

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1135,8 +1135,8 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 	return TRUE
 
 /client/proc/commendsomeone(var/forced = FALSE)
-	if(!can_commend(forced))
-		return
+/*	if(!can_commend(forced)) - REDMOON REMOVAL - uncommend_removal
+		return */
 	if(usr?.client?.prefs?.be_russian)
 		if(alert(src,"Был ли в этом раунде персонаж, действия которого вы хотели бы оценить?", "Оценка", "ДА", "НЕТ") != "ДА")
 			return
@@ -1180,8 +1180,10 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		else
 			to_chat(src,"You can't commend yourself.")
 		return
+/*		if(!can_commend(forced)) - REDMOON REMOVAL - перенесено вниз - WAS: prefs.commendedsomeone = TRUE 
+			return */
 	if(theykey)
-		// REDMOON REMOVAL - перенесено вниз - WAS: prefs.commendedsomeone = TRUE 
+//		prefs.commendedsomeone = TRUE - REDMOON REMOVAL - перенесено вниз - WAS: prefs.commendedsomeone = TRUE 
 		if(action == "Похвалить" || action == "Commend")
 			if(!can_commend(forced))
 				return

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -908,13 +908,15 @@ GLOBAL_LIST_INIT(name_adjustments, list())
 		dat += "<b>Русскоязычность:</b> <a href='?_src_=prefs;preference=be_russian'>[(be_russian) ? "Yes":"No"]</a><br>"
 		dat += "<b>Давать отпор:</b> <a href='?_src_=prefs;preference=be_defiant'>[(defiant) ? "Yes":"No"]</a><br>"
 		dat += "<b>Девственность:</b> <a href='?_src_=prefs;preference=be_virgin'>[(virginity) ? "Yes":"No"]</a><br>"
-		dat += "<b>Быть Голосом:</b> <a href='?_src_=prefs;preference=schizo_voice'>[(toggles & SCHIZO_VOICE) ? "Enabled":"Disabled"]</a>"
+		dat += "<b>Быть Голосом:</b> <a href='?_src_=prefs;preference=schizo_voice'>[(toggles & SCHIZO_VOICE) ? "Enabled":"Disabled"]</a><br>"
+		dat += "<b>Эффекты стресса:</b> <a href='?_src_=prefs;preference=stress_indicator'>[(redmoon_toggles & STRESS_EFFECTS) ? "Disabled":"Enabled"]</a>"
 	else
 		dat += "<b>Detailed Family:</b> <a href='?_src_=prefs;preference=detailed_family'>[(detailed_family_loging) ? "Yes":"No"]</a><br>" // REDMOON ADD - family_changes
 		dat += "<b>Be Russian:</b> <a href='?_src_=prefs;preference=be_russian'>[(be_russian) ? "Yes":"No"]</a><br>"
 		dat += "<b>Be defiant:</b> <a href='?_src_=prefs;preference=be_defiant'>[(defiant) ? "Yes":"No"]</a><br>"
 		dat += "<b>Be a virgin:</b> <a href='?_src_=prefs;preference=be_virgin'>[(virginity) ? "Yes":"No"]</a><br>"
-		dat += "<b>Be voice:</b> <a href='?_src_=prefs;preference=schizo_voice'>[(toggles & SCHIZO_VOICE) ? "Enabled":"Disabled"]</a>"
+		dat += "<b>Be voice:</b> <a href='?_src_=prefs;preference=schizo_voice'>[(toggles & SCHIZO_VOICE) ? "Enabled":"Disabled"]</a><br>"
+		dat += "<b>Stress effects:</b> <a href='?_src_=prefs;preference=stress_indicator'>[(redmoon_toggles & STRESS_EFFECTS) ? "Disabled":"Enabled"]</a>"
 	dat += "</td>"
 	dat += "</tr>"
 	dat += "</table>"
@@ -2522,6 +2524,12 @@ Slots: [job.spawn_positions]</span>
 					detailed_family_loging = !detailed_family_loging
 					if(detailed_family_loging)
 						to_chat(user, user.client.prefs?.be_russian ? span_notice("Детальная Семья включена. Вы будете получать подробные сообщения при попытке формирования семьи. Эта функция нужна для демонстрации работы подбора партнёра.") : span_notice("Detailed family log turned on."))
+
+				// disable_stress_indicator
+				if("stress_indicator")
+					redmoon_toggles ^= STRESS_EFFECTS
+					if(redmoon_toggles & STRESS_EFFECTS)
+						to_chat(user, span_notice("Индикатор стресса отключён. Вы не будете получать звуковое оповещение и иконку над персонажем, когда у него портится настроение (кроме критического падения морали)."))
 				// REDMOON ADD END
 
 				if("be_virgin")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -235,6 +235,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	//ROGUETOWN
 	parallax = PARALLAX_INSANE
 
+	redmoon_load_preferences(S)
 	return TRUE
 
 /datum/preferences/proc/save_preferences()
@@ -295,6 +296,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["key_bindings"], key_bindings)
 	WRITE_FILE(S["defiant"], defiant)
 	WRITE_FILE(S["prefer_old_chat"], prefer_old_chat)
+
+	redmoon_save_preferences(S)
 	return TRUE
 
 

--- a/modular_redmoon/code/modules/client/preferences.dm
+++ b/modular_redmoon/code/modules/client/preferences.dm
@@ -1,0 +1,14 @@
+/datum/preferences
+	var/negative_commented_someone = FALSE
+
+/client/proc/can_uncommend(silent = FALSE)
+	if(!prefs)
+		return FALSE
+	if(prefs.negative_commented_someone)
+		if(!silent)
+			if(usr?.client?.prefs?.be_russian)
+				to_chat(src, span_danger("Вы уже поругали кого-то в этом раунде."))
+			else
+				to_chat(src, span_danger("You already uncommended someone this round."))
+		return FALSE
+	return TRUE

--- a/modular_redmoon/code/modules/client/preferences.dm
+++ b/modular_redmoon/code/modules/client/preferences.dm
@@ -1,14 +1,4 @@
 /datum/preferences
+	var/redmoon_toggles = FALSE
 	var/negative_commented_someone = FALSE
 
-/client/proc/can_uncommend(silent = FALSE)
-	if(!prefs)
-		return FALSE
-	if(prefs.negative_commented_someone)
-		if(!silent)
-			if(usr?.client?.prefs?.be_russian)
-				to_chat(src, span_danger("Вы уже поругали кого-то в этом раунде."))
-			else
-				to_chat(src, span_danger("You already uncommended someone this round."))
-		return FALSE
-	return TRUE

--- a/modular_redmoon/code/modules/mob/living/overhead_effects.dm
+++ b/modular_redmoon/code/modules/mob/living/overhead_effects.dm
@@ -60,9 +60,13 @@
 	return
 
 /mob/living/proc/play_stress_indicator()
+	if(client?.prefs.redmoon_toggles & STRESS_EFFECTS)
+		return
 	play_overhead_indicator('icons/mob/overhead_effects.dmi', "stress", 15, OBJ_LAYER, private = TRUE, soundin = 'sound/ddstress.ogg')
 
 /mob/living/proc/play_relief_indicator()
+	if(client?.prefs.redmoon_toggles & STRESS_EFFECTS)
+		return
 	play_overhead_indicator('icons/mob/overhead_effects.dmi', "relief", 15, OBJ_LAYER, private = TRUE, soundin = 'sound/ddrelief.ogg')
 
 /mob/living/proc/play_mental_break_indicator()

--- a/modular_redmoon/modules/client/preferences_savefile.dm
+++ b/modular_redmoon/modules/client/preferences_savefile.dm
@@ -1,7 +1,4 @@
 /datum/preferences/proc/redmoon_character_pref_load(savefile/S)
-	S["be_russian"]										>> be_russian
-	S["donator_bonus_received"]    						>> donator_bonus_received
-
 	S["bark_id"] 										>> bark_id
 	S["bark_speed"] 									>> bark_speed
 	S["bark_pitch"] 									>> bark_pitch
@@ -12,7 +9,6 @@
 	S["family_surname"]									>> family_surname
 	S["family_genitals"] 								>> family_genitals
 	S["allow_latejoin_family"] 							>> allow_latejoin_family
-	S["detailed_family_loging"] 						>> detailed_family_loging
 
 	if(!islist(family_genitals) || !LAZYLEN(family_genitals))
 		family_genitals = list("Male", "Female")
@@ -57,9 +53,6 @@
 	_load_loadout(S)
 
 /datum/preferences/proc/redmoon_character_pref_save(savefile/S)
-	WRITE_FILE(S["be_russian"]							, be_russian)
-	WRITE_FILE(S["donator_bonus_received"]				, donator_bonus_received)
-
 	WRITE_FILE(S["bark_id"]								, bark_id)
 	WRITE_FILE(S["bark_speed"]							, bark_speed)
 	WRITE_FILE(S["bark_pitch"]							, bark_pitch)
@@ -74,7 +67,6 @@
 	WRITE_FILE(S["family_surname"] 						, family_surname) // family_changes - фамилия семьи
 	WRITE_FILE(S["family_genitals"] 					, family_genitals) // family_changes - проверка на половые органы партнёра
 	WRITE_FILE(S["allow_latejoin_family"] 				, allow_latejoin_family) // family_changes - разрешение на семью после раундстарта
-	WRITE_FILE(S["detailed_family_loging"] 				, detailed_family_loging) // family_changes - детальный отчёт по поиску семьи
 
 	WRITE_FILE(S["use_rumors"]							, use_rumors) // rumors_addition
 
@@ -127,3 +119,21 @@
 	S["loadout"] >> loadout_type
 	if (loadout_type)
 		loadout = new loadout_type()
+
+/datum/preferences/proc/redmoon_save_preferences(savefile/S)
+	WRITE_FILE(S["redmoon_toggles"] 					, redmoon_toggles) // gain_stress_indicator
+	WRITE_FILE(S["detailed_family_loging"] 				, detailed_family_loging) // family_changes
+	WRITE_FILE(S["be_russian"]							, be_russian) // translation
+	WRITE_FILE(S["donator_bonus_received"]				, donator_bonus_received) // PQ bonus for supporters
+
+/datum/preferences/proc/redmoon_load_preferences(savefile/S)
+	S["redmoon_toggles"] 								>> redmoon_toggles
+
+	// family_changes
+	S["detailed_family_loging"] 						>> detailed_family_loging
+
+	// translation
+	S["be_russian"]										>> be_russian
+
+	// PQ bonus for supporters
+	S["donator_bonus_received"]    						>> donator_bonus_received

--- a/modular_redmoon/modules/commend_comments/commend_comments.dm
+++ b/modular_redmoon/modules/commend_comments/commend_comments.dm
@@ -19,20 +19,13 @@
 /client/proc/add_uncommend(key, giver)
 	if(!giver || !key)
 		return
-	var/curcomm = 0
-	var/json_file = file("data/player_saves/[copytext(key,1,2)]/[key]/commends.json")
-	if(!fexists(json_file))
-		WRITE_FILE(json_file, "{}")
-	var/list/json = json_decode(file2text(json_file))
-	if(json[giver])
-		curcomm = json[giver]
 	var/fakekey = src.ckey
 	if(src.ckey in GLOB.anonymize)
 		fakekey = get_fake_key(src.ckey)
 
 	to_chat(src, span_danger("Укажите краткую причину этого изменения.<br>\
 	Учитывайте, что игрок может не знать всего контекста произошедших с вами событий и может быть НЕ их виной.<br>\
-	Ставьте негативную оценку только если навредили игровой атмосфере или произошёл гриф без веской причины.<br>\
+	Критикуйте только если навредили игровой атмосфере или произошёл гриф без веской причины. Не спамьте критикой.<br>\
 	Примеры - неуместный сленг, убийство бандитом при кооперации жертвы, пытки без видимой на то причины, не имеющее IC обоснования убийство, запирание до конца раунда без интересной игры, не подходящий сеттингу тёмного фэнтези отыгрыш.<br>\
 	В конце концов, спросите себя — <b>\"Это игра такая жестокая или это игрок перегнул палку?\"</b>"))
 
@@ -40,19 +33,8 @@
 	"Во-первых, вы точно приходите в онлайн игру, чтобы копить обиду там, куда приходят отдыхать? Во-вторых, подробно опишите причину негативной рецензии на чужую игру. Без оскорблений.", "Он точно заслужил это?", "", null)
 	if(!raisin)
 		to_chat(src, span_boldwarning("Причина не указана."))
-		fdel(json_file)
-		WRITE_FILE(json_file, json_encode(json))
 		return FALSE
 
-	if(curcomm >= 0) // Если комменд -1 или более, то нельзя дальше анкоммендить
-		adjust_playerquality(-1, ckey(key), fakekey, raisin)
-		send2irc("PQ", "[fakekey == ckey ? "[ckey]" : "[fake_key] ([ckey])"] [mob ? "([mob.real_name])" : ""] снял [key] за: \"<i>[raisin]</i>\"") // REDMOON ADD
-		curcomm--
-		json[giver] = curcomm
-		fdel(json_file)
-		WRITE_FILE(json_file, json_encode(json))
-		return TRUE
-	else
-		give_comment(-1, ckey(key), fakekey, raisin)
-		return TRUE
+	give_comment(-1, ckey(key), fakekey, raisin)
+	return TRUE
 

--- a/modular_redmoon/modules/commend_comments/commend_comments.dm
+++ b/modular_redmoon/modules/commend_comments/commend_comments.dm
@@ -38,3 +38,14 @@
 	give_comment(-1, ckey(key), fakekey, raisin)
 	return TRUE
 
+/client/proc/can_uncommend(silent = FALSE)
+	if(!prefs)
+		return FALSE
+	if(prefs.negative_commented_someone)
+		if(!silent)
+			if(usr?.client?.prefs?.be_russian)
+				to_chat(src, span_danger("Вы уже поругали кого-то в этом раунде."))
+			else
+				to_chat(src, span_danger("You already uncommended someone this round."))
+		return FALSE
+	return TRUE

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -9,7 +9,6 @@
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
 #include "_maps\conflict_marker.dm"
-#include "_maps\roguetest.dm"
 #include "_maps\templates\arcyne_fortress.dm"
 #include "_maps\templates\bog_shack_small.dm"
 #include "_maps\templates\sewers.dm"

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2192,6 +2192,7 @@
 #include "modular_redmoon\code\modules\cargo\packsrogue\bandit\clothing.dm"
 #include "modular_redmoon\code\modules\cargo\packsrogue\bandit\foresworn.dm"
 #include "modular_redmoon\code\modules\client\client_procs.dm"
+#include "modular_redmoon\code\modules\client\preferences.dm"
 #include "modular_redmoon\code\modules\client\preferences_toggles.dm"
 #include "modular_redmoon\code\modules\client\customizer\organ\fluff.dm"
 #include "modular_redmoon\code\modules\client\customizer\organ\genitals.dm"

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -9,6 +9,7 @@
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
 #include "_maps\conflict_marker.dm"
+#include "_maps\roguetest.dm"
 #include "_maps\templates\arcyne_fortress.dm"
 #include "_maps\templates\bog_shack_small.dm"
 #include "_maps\templates\sewers.dm"
@@ -201,6 +202,7 @@
 #include "code\__REDFINES\colors.dm"
 #include "code\__REDFINES\DNA.dm"
 #include "code\__REDFINES\mobs.dm"
+#include "code\__REDFINES\prefereces.dm"
 #include "code\__REDFINES\stats.dm"
 #include "code\__REDFINES\stress.dm"
 #include "code\__REDFINES\traits.dm"


### PR DESCRIPTION
# Описание

1. Uncommend и Commend теперь используют разные переменные. Можно хвалить и ругать по одному разу за раунд, а не только хвалить или ругать.
2. Uncommend больше не снимает PQ, но оставляет комментарий, которую видит игрок.
3. Исправлена неправильная запись настроек, от чего некоторые наши префы сохранялись только при сохранении у персонажа и могли некорректно переходить от одного к другому
4. Новый преф, позволяющий убрать звук от эффекта стресса.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.

## Причина изменений

https://discord.com/channels/1325992381899866183/1364838826245361665

## Демонстрация изменений

https://discord.com/channels/1325992381899866183/1364838826245361665