### PR TITLE
Добавляем гоблинов и полу-орков в артифицеров

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -310,7 +310,7 @@
 	if(SSround_end_statistics.species_humen)			shit += "<br><font color='#36693c'><span class='italics'>Люди: </span></font>[SSround_end_statistics.species_humen]"
 	if(SSround_end_statistics.species_moth)				shit += "<br><font color='#36693c'><span class='italics'>Моли: </span></font>[SSround_end_statistics.species_moth]"
 	if(SSround_end_statistics.species_demihuman)		shit += "<br><font color='#36693c'><span class='italics'>Полукровки: </span></font>[SSround_end_statistics.species_demihuman]"
-	if(SSround_end_statistics.species_halfork)			shit += "<br><font color='#36693c'><span class='italics'>Полуорки: </span></font>[SSround_end_statistics.species_halfork]"
+	if(SSround_end_statistics.species_halforc)			shit += "<br><font color='#36693c'><span class='italics'>Полуорки: </span></font>[SSround_end_statistics.species_halforc]"
 	if(SSround_end_statistics.species_halfelf)			shit += "<br><font color='#36693c'><span class='italics'>Полуэльфы: </span></font>[SSround_end_statistics.species_halfelf]"
 	if(SSround_end_statistics.species_lizardfolk)		shit += "<br><font color='#36693c'><span class='italics'>Сиссеане: </span></font>[SSround_end_statistics.species_lizardfolk]"
 	if(SSround_end_statistics.species_tabaxi)			shit += "<br><font color='#36693c'><span class='italics'>Табакси: </span></font>[SSround_end_statistics.species_tabaxi]"

--- a/code/modules/jobs/job_types/roguetown/yeomen/artificier.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/artificier.dm
@@ -6,7 +6,7 @@
 	total_positions = 2
 	spawn_positions = 2
 
-	allowed_races = RACES_SHUNNED_UP
+	allowed_races = RACES_ALL_KINDS // REDMOON EDIT - goblins_jobs_changes - WAS: RACES_SHUNNED_UP
 	allowed_sexes = list(MALE, FEMALE)
 
 	tutorial = "Hidden in the depths are ancient mechanical secrets, something your creed has taken it upon themselves to studying and understanding. To some, these mechanical wonders may seem like magic, but you know their inner workings as well as you do stone, down to the last cog."
@@ -51,6 +51,10 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/treatment, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, 2, TRUE)
+	// REDMOON ADD START - goblins_jobs_changes
+	if(isgoblinp(H) || ishalforc(H))
+		H.change_stat("intelligence", 3) // Перекрывает расовый дебаф + 1
+	// REDMOON ADD END
 
 	H.change_stat("strength", 1)
 	H.change_stat("intelligence", 2)

--- a/modular_redmoon/code/modules/tgs/roundspoke.dm
+++ b/modular_redmoon/code/modules/tgs/roundspoke.dm
@@ -176,7 +176,7 @@
 	Люди: [SSround_end_statistics.species_humen] | \
 	Моли: [SSround_end_statistics.species_moth] | \
 	Полукровки: [SSround_end_statistics.species_demihuman] | \
-	Полуорки: [SSround_end_statistics.species_halfork] | \
+	Полуорки: [SSround_end_statistics.species_halforc] | \
 	Полуэльфы: [SSround_end_statistics.species_halfelf] | \
 	Сиссеане: [SSround_end_statistics.species_lizardfolk] | \
 	Табакси: [SSround_end_statistics.species_tabaxi] | \

--- a/modular_redmoon/modules/stats_reports_with_gender_list/stats_reports_with_gender_lists.dm
+++ b/modular_redmoon/modules/stats_reports_with_gender_list/stats_reports_with_gender_lists.dm
@@ -19,7 +19,7 @@ SUBSYSTEM_DEF(round_end_statistics)
 	var/species_elf = 0
 	var/species_goblinp = 0
 	var/species_halfelf = 0
-	var/species_halfork = 0
+	var/species_halforc = 0
 	var/species_humen = 0 
 	var/species_kobold = 0
 	var/species_kraukalee = 0
@@ -54,7 +54,7 @@ SUBSYSTEM_DEF(round_end_statistics)
 		if(/datum/species/elf/dark) SSround_end_statistics.species_drow++
 		if(/datum/species/elf/wood) SSround_end_statistics.species_elf++
 		if(/datum/species/goblinp) SSround_end_statistics.species_goblinp++
-		if(/datum/species/halforc) SSround_end_statistics.species_halfork++
+		if(/datum/species/halforc) SSround_end_statistics.species_halforc++
 		if(/datum/species/human/halfelf) SSround_end_statistics.species_halfelf++
 		if(/datum/species/human/northern) SSround_end_statistics.species_humen++
 		if(/datum/species/kobold) SSround_end_statistics.species_kobold++


### PR DESCRIPTION
# Описание

Они получают +3 к интеллекту от профессии дополнительно. Потому что типичный слот для них.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.

## Причина изменений

https://discord.com/channels/1325992381899866183/1358525182570139738

## Демонстрация изменений

https://discord.com/channels/1325992381899866183/1358525182570139738