### PR TITLE
Время становления зомби увеличено с 4 минут до 10 минут

### DIFF
--- a/code/datums/components/rotting.dm
+++ b/code/datums/components/rotting.dm
@@ -64,7 +64,7 @@
 		qdel(src)
 		return
 
-	if(amount > 4 MINUTES)
+	if(amount > 10 MINUTES) // REDMOON EDIT - время становления зомби увеличено с 4 минут до 10 минут
 		if(is_zombie)
 			var/datum/antagonist/zombie/Z = C.mind.has_antag_datum(/datum/antagonist/zombie)
 			if(Z && !Z.has_turned && !Z.revived && C.stat == DEAD)


### PR DESCRIPTION
# Описание

В шапке.
Предлагали до 8 минут. Сделал до 10. т.к.:
Мне кажется, зомби привносят в игру мало реальных угроз и интереса, и тем не менее, приносят. Поднятие таймера для случаев, когда умерли где-то в населенном месте до подобного значения, позволит куда оперативнее принять меры.

- [x] Этот пулл-реквест готов к тест-мерджу.

## Причина изменений

https://discord.com/channels/1325992381899866183/1343564703590387783

## Демонстрация изменений

https://discord.com/channels/1325992381899866183/1343564703590387783