### PR TITLE
Исправление, что атеизм автоматически убирался у многих профессий и классов (можно в ТМ)

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -215,7 +215,9 @@
 	/datum/patron/divine/eora\
 )
 
+// REDMOON ADD - добавлен /datum/patron/godless
 #define ALL_PATRONS list(\
+	/datum/patron/godless,\
 	/datum/patron/divine/astrata,\
 	/datum/patron/divine/noc,\
 	/datum/patron/divine/dendor,\
@@ -270,7 +272,8 @@
 	INHUMEN_CURSES\
 )
 
-#define ALL_NON_INHUMEN_PATRONS list(/datum/patron/divine/astrata, /datum/patron/divine/noc, /datum/patron/divine/dendor, /datum/patron/divine/abyssor, /datum/patron/divine/ravox, /datum/patron/divine/necra, /datum/patron/divine/xylix, /datum/patron/divine/pestra, /datum/patron/divine/malum, /datum/patron/divine/eora, /datum/patron/psydon)
+// REDMOON ADD - добавлен /datum/patron/godless
+#define ALL_NON_INHUMEN_PATRONS list(/datum/patron/divine/astrata, /datum/patron/divine/noc, /datum/patron/divine/dendor, /datum/patron/divine/abyssor, /datum/patron/divine/ravox, /datum/patron/divine/necra, /datum/patron/divine/xylix, /datum/patron/divine/pestra, /datum/patron/divine/malum, /datum/patron/divine/eora, /datum/patron/psydon, /datum/patron/godless)
 
 #define PLATEHIT "plate"
 #define CHAINHIT "chain"


### PR DESCRIPTION

# Описание

Исправляет форс любого из патронов десятки для таких ролей как:
У рефуг:
- Странствующий проповедник
- Рыцарь
- Рыцарь-капитан
- Привратник
- Десятник

Исправляет форс любого из имеющихся в игре божественных патронов для таких ролей, как:
- вагабонд
- ундердвеллеры
- скевенджеры
- роги
- артисты
- ноблы-рефуги
- торговец
- магос-рефуга
- целитель
- дезертир

- [x] Этот пулл-реквест готов к тест-мерджу.

## Причина изменений

Фиксы


