### PR TITLE
Возвращение set hand

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -306,6 +306,10 @@ GLOBAL_LIST_INIT(name_adjustments, list())
 				dat += "<a href='?_src_=prefs;preference=antag;task=menu'>Антагонисты</a>"
 			else
 				dat += "<a href='?_src_=prefs;preference=antag;task=menu'>Villain Selection</a>"
+			if(usr?.client?.prefs?.be_russian)
+				dat += "<a href='?_src_=prefs;preference=additional_settings;task=menu'>Дополнительные настройки</a>"
+			else
+				dat += "<a href='?_src_=prefs;preference=additional_settings;task=menu'>Additional Settings</a>"
 			dat += "</td>"
 
 			dat += "<td style='width:33%;text-align:right'>"
@@ -1429,7 +1433,19 @@ Slots: [job.spawn_positions]</span>
 				SetAntag(user)
 			else
 				SetAntag(user)
-
+	else if(href_list["preference"] == "additional_settings")
+		switch(href_list["task"])
+			if("close")
+				user << browse(null, "window=additional_settings")
+				ShowChoices(user)
+			if("set_hand")
+				var/potential_hand_ckey = input(usr, "Введите Byond Login (CKEY) игрока, которого вы хотели бы видеть в качестве десницы (эту настройку можно изменять посреди раунда) Те, кто не выставлен в качестве десницы, не смогут зайти за неё ни в начале, ни в процессе раунда..", "Bloodbinding", hand_ckey) as text
+				if(!potential_hand_ckey)
+					hand_ckey = ""
+				hand_ckey = potential_hand_ckey
+				AdditionalSettings(user)
+			else
+				AdditionalSettings(user)
 	else if(href_list["preference"] == "triumphs")
 		user.show_triumphs_list()
 
@@ -2849,3 +2865,19 @@ Slots: [job.spawn_positions]</span>
 	if(is_misc_banned(parent.ckey, BAN_MISC_RESPAWN))
 		return FALSE
 	return TRUE
+
+/datum/preferences/proc/AdditionalSettings(mob/user)
+	var/list/dat = list()
+
+	dat += "<style>label { display: inline-block; width: 200px; }</style><body>"
+
+	dat += "<center><a href='?_src_=prefs;preference=additional_settings;task=close'>Done</a></center><br>"
+
+	dat += "<b>Set Hand: <a href='?_src_=prefs;preference=additional_settings;task=set_hand'>[hand_ckey ? hand_ckey : "(Anyone)"]</a></b>"
+
+	dat += "</body>"
+
+	var/datum/browser/noclose/popup = new(user, "additional_settings", "<div align='center'>Additional Settings</div>", 250, 300) //no reason not to reuse the occupation window, as it's cleaner that way
+	popup.set_window_options("can_close=0")
+	popup.set_content(dat.Join())
+	popup.open(FALSE)

--- a/modular_redmoon/code/modules/client/preferences.dm
+++ b/modular_redmoon/code/modules/client/preferences.dm
@@ -1,4 +1,4 @@
 /datum/preferences
 	var/redmoon_toggles = FALSE
 	var/negative_commented_someone = FALSE
-
+	var/hand_ckey = ""

--- a/modular_redmoon/modules/client/preferences_savefile.dm
+++ b/modular_redmoon/modules/client/preferences_savefile.dm
@@ -16,6 +16,9 @@
 	// rumors_addition
 	S["use_rumors"]										>> use_rumors
 
+	// Sethand remoake
+	S["hand_ckey"]										>> hand_ckey
+
 	// String
 	S["rumors_prefered_behavior_in_combat"]				>> rumors_prefered_behavior_in_combat
 	S["rumors_prefered_behavior_with_problems"]			>> rumors_prefered_behavior_with_problems
@@ -69,6 +72,8 @@
 	WRITE_FILE(S["allow_latejoin_family"] 				, allow_latejoin_family) // family_changes - разрешение на семью после раундстарта
 
 	WRITE_FILE(S["use_rumors"]							, use_rumors) // rumors_addition
+
+	WRITE_FILE(S["hand_ckey"]							, hand_ckey) // sethand remake
 
 	// String
 	WRITE_FILE(S["rumors_prefered_behavior_with_problems"]	, rumors_prefered_behavior_with_problems) // rumors_addition

--- a/modular_redmoon/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/modular_redmoon/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -4,3 +4,31 @@
 		Вы много лет служили своему дворянскому дому, став мастером интриг и знаете как подбирать слова, чтобы добиться своего. \
 		Пусть люд не забывает, кому вы нашёптываете советы, ибо этим вы убили больше людей, чем любой мастер фехтования мог бы себе представить."
 	cmode_music = 'sound/music/cmode/nobility/combat_noble.ogg'
+
+// sethand remake
+/datum/job/roguetown/hand/special_check_latejoin(client/C)
+	if(SSjob.name_occupations["Duke"].current_positions <= 0)
+		return
+	for(var/mob/living/carbon/human/duke in GLOB.player_list)
+		if(duke.mind.assigned_role == "Duke")
+			if(duke.client.prefs.hand_ckey)
+				if(lowertext(duke.client.prefs.hand_ckey) == C.ckey)
+					return TRUE
+				else
+					return
+
+// sethand remake
+/datum/job/roguetown/hand/special_job_check(mob/dead/new_player/player)
+	if(!player)
+		return
+	if(!player.ckey)
+		return
+	for(var/mob/dead/new_player/duke in GLOB.player_list)
+		if(duke.mind.assigned_role == "Duke")
+			if(duke.client.prefs.hand_ckey)
+				if(lowertext(duke.client.prefs.hand_ckey) == player.ckey)
+					to_chat(player, span_biginfo("[duke.mind.current.gender == MALE ? "Герцог" : "Герцогиня"] хочет видеть своей десницей именно тебя. Не подведи [duke.mind.current.gender == MALE ? "его" : "её"]."))
+					return TRUE
+				else
+					to_chat(player, span_warning("У герцога есть другой человек, которого он хотел бы видеть своей десницей."))
+					return


### PR DESCRIPTION
# Описание

1. Добавлен возможность зайти за десницу в процессе раунда (только если в раунде уже есть герцог)
2. Добавлена возможность герцогу выставить через новое меню дополнительных настроек то, какого игрока он хочет видеть в качестве своей десницы.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.

## Причина изменений

Хоть кому-то герцог должен доверять.

## Демонстрация изменений

![image](https://github.com/user-attachments/assets/58a930eb-b391-4539-846b-3119c86bdfd8)
